### PR TITLE
Add an association from establishments to profiles

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -11,7 +11,8 @@ module.exports = db => {
   const Profile = ProfileModel(db);
 
   Establishment.places = Establishment.hasMany(Place);
-  Establishment.roles = Establishment.hasMany(Role);
+  Establishment.hasMany(Role);
+  Establishment.hasMany(Profile);
 
   Place.nacwo = Place.belongsTo(Role, { as: 'nacwo' });
   Place.establishment = Place.belongsTo(Establishment, { as: 'establishment' });


### PR DESCRIPTION
This allows the API to easily retrieve a list of profiles for a particular establishment by adding a `getProfiles` method to establishment models.