### PR TITLE
Make address fields non-mandatory

### DIFF
--- a/schema/profile.js
+++ b/schema/profile.js
@@ -12,8 +12,8 @@ module.exports = db => {
     position: STRING,
     qualifications: STRING,
     certifications: STRING,
-    address: { type: STRING, allowNull: false },
-    postcode: { type: STRING, allowNull: false },
+    address: STRING,
+    postcode: STRING,
     email: { type: STRING, allowNull: false },
     telephone: { type: STRING, allowNull: false },
     notes: TEXT


### PR DESCRIPTION
These are not currently present on the PIL data, so creating a person profile from a PIL needs the address fields to be non-mandatory.