### PR TITLE
Refactor relation between profiles and establishments

### DIFF
--- a/schema/index.js
+++ b/schema/index.js
@@ -6,6 +6,7 @@ const AuthorisationModel = require('./authorisation');
 const TrainingModuleModel = require('./training-module');
 const PILModel = require('./pil');
 const ProjectModel = require('./project');
+const PermissionModel = require('./permission');
 
 module.exports = db => {
 
@@ -13,6 +14,7 @@ module.exports = db => {
   const Place = PlaceModel(db);
   const Role = RoleModel(db);
   const Profile = ProfileModel(db);
+  const Permission = PermissionModel(db);
   const Authorisation = AuthorisationModel(db);
   const PIL = PILModel(db);
   const Project = ProjectModel(db);
@@ -21,7 +23,7 @@ module.exports = db => {
   Establishment.places = Establishment.hasMany(Place);
   Establishment.authorisations = Establishment.hasMany(Authorisation);
   Establishment.hasMany(Role);
-  Establishment.hasMany(Profile);
+  Establishment.belongsToMany(Profile, { through: Permission });
   Establishment.hasMany(PIL);
   Establishment.hasMany(Project);
 
@@ -33,7 +35,7 @@ module.exports = db => {
   Profile.hasMany(Role);
   Profile.hasMany(TrainingModule, { foreignKey: 'profileId' });
 
-  Profile.establishment = Profile.belongsTo(Establishment);
+  Profile.belongsToMany(Establishment, { through: Permission });
 
   PIL.establishment = PIL.belongsTo(Establishment);
   PIL.profile = PIL.belongsTo(Profile);

--- a/schema/permission.js
+++ b/schema/permission.js
@@ -1,0 +1,11 @@
+const { ENUM } = require('sequelize');
+
+module.exports = db => {
+
+  const Permission = db.define('permission', {
+    role: { type: ENUM('basic', 'read', 'admin'), defaultValue: 'basic', allowNull: false }
+  });
+
+  return Permission;
+
+};

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -5,6 +5,7 @@ module.exports = db => {
   const Profile = db.define('profile', {
     id: { type: UUID, defaultValue: UUIDV1, primaryKey: true },
     migrated_id: STRING,
+    userId: { type: STRING, unique: true },
     title: { type: STRING, allowNull: false },
     firstName: { type: STRING, allowNull: false },
     lastName: { type: STRING, allowNull: false },


### PR DESCRIPTION
A profile can be shared across multiple establishments with differing permissions at each one.

To facilitate this, instead of having a one-to-many relation between profiles and establishments, make the relation many-to-many with a `permission` property on each association.