### PR TITLE
Make database migrator deployable

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,6 @@ pipeline:
     commands:
       - docker build --build-arg NPM_AUTH_USERNAME=$${NPM_AUTH_USERNAME} --build-arg NPM_AUTH_TOKEN=$${NPM_AUTH_TOKEN} -t asl-schema .
     when:
-      branch: master
       event: tag
 
   image_to_quay:
@@ -42,7 +41,6 @@ pipeline:
       - docker tag asl quay.io/ukhomeofficedigital/asl-schema:$${DRONE_TAG}
       - docker push quay.io/ukhomeofficedigital/asl-schema:$${DRONE_TAG}
     when:
-      branch: master
       event: tag
 
   configure_deploy:

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,60 @@ pipeline:
     when:
       event: tag
 
+  build:
+    image: docker:17.09.1
+    secrets:
+      - npm_auth_token
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker build --build-arg NPM_AUTH_USERNAME=$${NPM_AUTH_USERNAME} --build-arg NPM_AUTH_TOKEN=$${NPM_AUTH_TOKEN} -t asl-schema .
+    when:
+      branch: master
+      event: tag
+
+  image_to_quay:
+    image: docker:17.09.1
+    secrets:
+      - docker_password
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker login -u="ukhomeofficedigital+asl" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag asl quay.io/ukhomeofficedigital/asl-schema:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/asl-schema:$${DRONE_TAG}
+    when:
+      branch: master
+      event: tag
+
+  configure_deploy:
+    image: node:8
+    secrets:
+      - npm_auth_token
+    commands:
+      - mkdir deploy
+      - npx kube-cookbook --out deploy .kube.$${DRONE_DEPLOY_TO}.yaml
+    when:
+      environment:
+        - dev
+        - preprod
+      event: deployment
+
+  dev_deploy:
+    image: quay.io/ukhomeofficedigital/kd:v0.5.0
+    environment:
+      KUBE_NAMESPACE: asl-dev
+      INSECURE_SKIP_TLS_VERIFY: "TRUE"
+    secrets:
+      - kube_server
+      - kube_token_dev
+    commands:
+      - export KUBE_TOKEN=$${KUBE_TOKEN_DEV}
+      - kd -f deploy
+    when:
+      environment: dev
+      event: deployment
+
 matrix:
   NPM_AUTH_USERNAME:
     - asl

--- a/.kube.dev.yaml
+++ b/.kube.dev.yaml
@@ -1,0 +1,25 @@
+---
+- name: database-admin
+  recipe: worker
+  image: quay.io/ukhomeofficedigital/asl-schema:{{.DRONE_TAG}}
+  env:
+    DATABASE_HOST:
+      secret: true
+      name: asl-dev-rds
+      key: endpoint
+    DATABASE_NAME:
+      secret: true
+      name: asl-dev-rds
+      key: db_name
+    DATABASE_USERNAME:
+      secret: true
+      name: asl-dev-rds
+      key: username
+    DATABASE_PASSWORD:
+      secret: true
+      name: asl-dev-rds
+      key: password
+    DATABASE_PORT:
+      secret: true
+      name: asl-dev-rds
+      key: port

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/ukhomeofficedigital/nodejs-base:v8
+
+RUN npm install -g npm@6
+
+COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
+RUN npm ci --production --no-optional
+COPY . /app
+
+RUN rm /app/.npmrc
+
+USER 999
+
+CMD npm run migrate

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
     "test:unit": "mocha",
+    "migrate": "knex migrate:latest",
+    "rollback": "knex migrate:rollback",
     "seed": "knex seed:run"
   },
   "repository": {


### PR DESCRIPTION
This will allow the schema to be deployed to ACP and runs the latest migration against the dev database on deloyment of a particular tag when deployed.