### PR TITLE
Fix user/username mismatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,11 @@ const Knex = require('knex');
 const Schema = require('./schema');
 
 module.exports = connection => {
+
+  if (connection.username && !connection.user) {
+    connection.user = connection.username;
+  }
+
   const settings = {
     client: 'pg',
     useNullAsDefault: true,


### PR DESCRIPTION
Because sequelize used `username` and knex uses `user` then there's some config which is potentially broken. This provides some bulletproof socks.