### PR TITLE
Scope the `orWhere` in people search to only the licence number query

### DIFF
--- a/schema/profile.js
+++ b/schema/profile.js
@@ -84,8 +84,11 @@ class Profile extends BaseModel {
 
     if (search) {
       query
-        .where('pil.licenceNumber', 'iLike', search && `%${search}%`)
-        .orWhere(builder => this.searchFullName({ search, query: builder }));
+        .where(builder => {
+          return builder
+            .where('pil.licenceNumber', 'iLike', search && `%${search}%`)
+            .orWhere(builder => this.searchFullName({ search, query: builder }));
+        });
     }
 
     query = this.paginate({ query, limit, offset });


### PR DESCRIPTION
Previously the `orWhere` was being applied to the entire query, so names that matched would negate any checks on establishment association or role filters.

By wrapping the queries into a sub-query the `orWhere` could be scoped to only negate the licence number match.