### PR TITLE
Add credentials and config for npm install in docker

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,9 +17,9 @@ pipeline:
     environment:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
-      - docker build -t asl-schema .
+      - docker build --build-arg NPM_AUTH_USERNAME=$${NPM_AUTH_USERNAME} --build-arg NPM_AUTH_TOKEN=$${NPM_AUTH_TOKEN} -t asl-schema .
     when:
-      event: tag
+      event: [tag, pull_request]
 
   image_to_quay:
     image: docker:17.09.1

--- a/.npmrc
+++ b/.npmrc
@@ -2,5 +2,3 @@
 
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:username=${NPM_AUTH_USERNAME}
 //artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:_password=${NPM_AUTH_TOKEN}
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:email=leonard.martin@digital.homeoffice.gov.uk
-//artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/:always-auth=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG NPM_AUTH_TOKEN
 
 RUN npm install -g npm@6
 
+COPY .npmrc /app/.npmrc
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 RUN npm ci --production --no-optional

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/ukhomeofficedigital/nodejs-base:v8
 
+ARG NPM_AUTH_USERNAME
+ARG NPM_AUTH_TOKEN
+
 RUN npm install -g npm@6
 
 COPY package.json /app/package.json


### PR DESCRIPTION
We've added modules scoped under `@asl/*` which need credentials setting to be able to install from artifactory.