### PR TITLE
add validate() method to base-model

### DIFF
--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -1,5 +1,6 @@
 const { isUndefined } = require('lodash');
 const { Model } = require('objection');
+const ValidationError = require('./validation-error');
 
 class SoftDeleteQueryBuilder extends Model.QueryBuilder {
   delete() {
@@ -87,7 +88,7 @@ class BaseModel extends Model {
     try {
       this.fromJson(data);
     } catch (error) {
-      return error;
+      return new ValidationError(error);
     }
   }
 }

--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -82,6 +82,14 @@ class BaseModel extends Model {
     return query
       .orderBy(sort.column, sort.ascending === 'true' ? 'asc' : 'desc');
   }
+
+  static validate(data) {
+    try {
+      this.fromJson(data);
+    } catch (error) {
+      return error;
+    }
+  }
 }
 
 module.exports = BaseModel;

--- a/schema/validation-error.js
+++ b/schema/validation-error.js
@@ -1,0 +1,17 @@
+class ValidationError extends Error {
+  constructor(error) {
+    if (typeof error === 'string') {
+      super(error);
+    } else if (typeof error === 'object') {
+      super();
+      Object.assign(this, error);
+    } else {
+      super('validation error');
+    }
+
+    this.name = this.constructor.name;
+    this.status = 400;
+  }
+}
+
+module.exports = ValidationError;

--- a/test/base-model.js
+++ b/test/base-model.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 const Authorisation = require('../schema/authorisation'); // BaseModel has no schema of it's own
-const ValidationError = require('objection/lib/model/ValidationError');
+const ValidationError = require('../schema/validation-error');
 
 describe('BaseModel', () => {
   it('provides a validation method which returns a validation error instead of throwing', () => {

--- a/test/base-model.js
+++ b/test/base-model.js
@@ -1,0 +1,10 @@
+const expect = require('chai').expect;
+const Authorisation = require('../schema/authorisation'); // BaseModel has no schema of it's own
+const ValidationError = require('objection/lib/model/ValidationError');
+
+describe('BaseModel', () => {
+  it('provides a validation method which returns a validation error instead of throwing', () => {
+    const badJson = {};
+    expect(Authorisation.validate(badJson)).to.be.an.instanceof(ValidationError);
+  });
+});

--- a/test/validation-error.js
+++ b/test/validation-error.js
@@ -1,0 +1,24 @@
+const expect = require('chai').expect;
+const ValidationError = require('../schema/validation-error');
+
+describe('ValidationError', () => {
+  it('can be instantiated with a message string', () => {
+    const error = new ValidationError('this is an error');
+    expect(error.message).to.equal('this is an error');
+  });
+
+  it('can be instantiated with an error object', () => {
+    const error = new ValidationError({ message: 'this is an error' });
+    expect(error.message).to.equal('this is an error');
+  });
+
+  it('has a default error message', () => {
+    const error = new ValidationError();
+    expect(error.message).to.equal('validation error');
+  });
+
+  it('has a default status code', () => {
+    const error = new ValidationError();
+    expect(error.status).to.equal(400);
+  });
+});


### PR DESCRIPTION
Added a `validate()` method that returns the error rather than throwing it.