### PR TITLE
Allow container to run even if migrate fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY . /app
 
 RUN rm /app/.npmrc
 
-CMD npm run migrate && ./keepalive.sh
+CMD npm run migrate & ./keepalive.sh


### PR DESCRIPTION
The container is failing on dev, but we can't shell into it to debug/fix because the container crashes immediately. Instead allow it to keep running even if migrate fails.