### PR TITLE
schema ValidationError wasn't picking up the message from the objection error

### DIFF
--- a/schema/validation-error.js
+++ b/schema/validation-error.js
@@ -3,8 +3,7 @@ class ValidationError extends Error {
     if (typeof error === 'string') {
       super(error);
     } else if (typeof error === 'object') {
-      super();
-      Object.assign(this, error);
+      super(error.message);
     } else {
       super('validation error');
     }

--- a/test/validation-error.js
+++ b/test/validation-error.js
@@ -1,5 +1,6 @@
 const expect = require('chai').expect;
 const ValidationError = require('../schema/validation-error');
+const ObjectionValidationError = require('objection/lib/model/ValidationError');
 
 describe('ValidationError', () => {
   it('can be instantiated with a message string', () => {
@@ -9,6 +10,12 @@ describe('ValidationError', () => {
 
   it('can be instantiated with an error object', () => {
     const error = new ValidationError({ message: 'this is an error' });
+    expect(error.message).to.equal('this is an error');
+  });
+
+  it('can be instantiated with an objection ValidationError object', () => {
+    const objectionError = new ObjectionValidationError({ message: 'this is an error' });
+    const error = new ValidationError(objectionError);
     expect(error.message).to.equal('this is an error');
   });
 


### PR DESCRIPTION
Object assign wasn't calling the message method on the objection error so it wasn't setting the message property.

We don't really need the other properties from the original error so I've just removed the copy.