### PR TITLE
allow migrated_id to be null

### DIFF
--- a/schema/establishment.js
+++ b/schema/establishment.js
@@ -13,7 +13,7 @@ class Establishment extends BaseModel {
       additionalProperties: false,
       properties: {
         id: { type: 'integer' },
-        'migrated_id': { type: 'string' },
+        'migrated_id': { type: ['string', 'null'] },
         name: { type: 'string' },
         type: { type: ['string', 'null'] },
         status: {

--- a/schema/pil.js
+++ b/schema/pil.js
@@ -13,7 +13,7 @@ class PIL extends BaseModel {
       additionalProperties: false,
       properties: {
         id: { type: 'string' },
-        'migrated_id': { type: 'string' },
+        'migrated_id': { type: ['string', 'null'] },
         status: {
           type: 'string',
           enum: pilStatuses

--- a/schema/place.js
+++ b/schema/place.js
@@ -14,7 +14,7 @@ class Place extends BaseModel {
       additionalProperties: false,
       properties: {
         id: { type: 'string' },
-        'migrated_id': { type: 'string' },
+        'migrated_id': { type: ['string', 'null'] },
         site: { type: 'string' },
         area: { type: ['string', 'null'] },
         name: { type: 'string' },

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -13,7 +13,7 @@ class Profile extends BaseModel {
       additionalProperties: false,
       properties: {
         id: { type: 'string' },
-        'migrated_id': { type: 'string' },
+        'migrated_id': { type: ['string', 'null'] },
         userId: { type: 'string' },
         title: { type: ['string', 'null'] },
         firstName: { type: 'string' },

--- a/schema/project.js
+++ b/schema/project.js
@@ -14,7 +14,7 @@ class Project extends BaseModel {
       additionalProperties: false,
       properties: {
         id: { type: 'string' },
-        'migrated_id': { type: 'string' },
+        'migrated_id': { type: ['string', 'null'] },
         status: {
           type: 'string',
           enum: projectStatuses

--- a/schema/role.js
+++ b/schema/role.js
@@ -13,7 +13,7 @@ class Role extends BaseModel {
       additionalProperties: false,
       properties: {
         id: { type: 'string' },
-        'migrated_id': { type: 'string' },
+        'migrated_id': { type: ['string', 'null'] },
         type: {
           type: 'string',
           enum: roles


### PR DESCRIPTION
This got accidentally reverted in one of the previous PRs.