### PR TITLE
AS-579: remove required props on establishment

### DIFF
--- a/migrations/20180823120301_remove_required_props_on_establishment.js
+++ b/migrations/20180823120301_remove_required_props_on_establishment.js
@@ -1,0 +1,33 @@
+const alterEnumColumn = (tableName, columnName, enums, nullable = true) => {
+  const constraintName = `${tableName}_${columnName}_check`;
+  return [
+    `ALTER TABLE ${tableName} DROP CONSTRAINT IF EXISTS ${constraintName};`,
+    `ALTER TABLE ${tableName} ADD CONSTRAINT ${constraintName} CHECK (${columnName} = ANY (ARRAY['${enums.join(
+      "'::text, '"
+    )}'::text]));`,
+    `ALTER TABLE ${tableName} ALTER COLUMN ${columnName} ${nullable ? 'DROP' : 'SET'} NOT NULL`
+  ].join('\n');
+};
+
+
+exports.up = async function up(knex) {
+  await knex.raw(
+    alterEnumColumn('establishments', 'country', ['england', 'scotland', 'wales', 'ni'], true)
+  );
+
+  await knex.schema.alterTable('establishments', table => {
+    table.string('address').nullable().alter();
+    table.string('email').nullable().alter();
+  });
+};
+
+exports.down = async function down(knex) {
+  await knex.raw(
+    alterEnumColumn('establishments', 'country', ['england', 'scotland', 'wales', 'ni'], false)
+  );
+
+  await knex.schema.alterTable('establishments', table => {
+    table.string('address').notNullable().alter();
+    table.string('email').notNullable().alter();
+  });
+};

--- a/schema/establishment.js
+++ b/schema/establishment.js
@@ -9,7 +9,7 @@ class Establishment extends BaseModel {
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['name', 'address', 'country', 'email'],
+      required: ['id', 'name'],
       additionalProperties: false,
       properties: {
         id: { type: 'integer' },

--- a/test/unit/authorisation.js
+++ b/test/unit/authorisation.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const Authorisation = require('../schema/authorisation');
+const Authorisation = require('../../schema/authorisation');
 const ValidationError = require('objection/lib/model/ValidationError');
 
 describe('Authorisation', () => {

--- a/test/unit/base-model.js
+++ b/test/unit/base-model.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
-const Authorisation = require('../schema/authorisation'); // BaseModel has no schema of it's own
-const ValidationError = require('../schema/validation-error');
+const Authorisation = require('../../schema/authorisation'); // BaseModel has no schema of it's own
+const ValidationError = require('../../schema/validation-error');
 
 describe('BaseModel', () => {
   it('provides a validation method which returns a validation error instead of throwing', () => {

--- a/test/unit/establishment.js
+++ b/test/unit/establishment.js
@@ -1,10 +1,11 @@
 const expect = require('chai').expect;
-const Establishment = require('../schema/establishment');
+const Establishment = require('../../schema/establishment');
 const ValidationError = require('objection/lib/model/ValidationError');
 
 describe('Establishment', () => {
   it('throws a validation error when required properties are missing', () => {
     const badJson = {
+      id: 80001,
       address: 'University of Croydon',
       email: 'vice-chancellor@croydon.ac.uk'
     };
@@ -13,6 +14,7 @@ describe('Establishment', () => {
 
   it('throws a validation error when invalid values are provided', () => {
     const badJson = {
+      id: 80001,
       name: 'University of Croydon',
       address: 'University of Croydon',
       email: 'vice-chancellor@croydon.ac.uk',
@@ -23,6 +25,7 @@ describe('Establishment', () => {
 
   it('throws a validation error when unknown values are provided', () => {
     const badJson = {
+      id: 80001,
       name: 'University of Croydon',
       address: 'University of Croydon',
       email: 'vice-chancellor@croydon.ac.uk',
@@ -34,6 +37,7 @@ describe('Establishment', () => {
 
   it('successfully instantiates when given a valid schema', () => {
     const goodJson = {
+      id: 80001,
       name: 'University of Croydon',
       address: 'University of Croydon',
       email: 'vice-chancellor@croydon.ac.uk',
@@ -44,6 +48,7 @@ describe('Establishment', () => {
 
   it('allows null values for non-required fields', () => {
     const goodJson = {
+      id: 80001,
       name: 'University of Croydon',
       address: 'University of Croydon',
       email: 'vice-chancellor@croydon.ac.uk',

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const Schema = require('../schema');
+const Schema = require('../../schema');
 
 describe('Schema', () => {
 

--- a/test/unit/invitation.js
+++ b/test/unit/invitation.js
@@ -1,23 +1,23 @@
 const expect = require('chai').expect;
-const Permission = require('../schema/permission');
+const Invitation = require('../../schema/invitation');
 const ValidationError = require('objection/lib/model/ValidationError');
 
-describe('Permission', () => {
+describe('Invitation', () => {
   it('throws a validation error when required properties are missing', () => {
     const badJson = {
-      establishmentId: 'abcd-1234',
+      establishmentId: 100,
       profileId: '1234567'
     };
-    expect(() => Permission.fromJson(badJson)).to.throw(ValidationError, /required/);
+    expect(() => Invitation.fromJson(badJson)).to.throw(ValidationError, /required/);
   });
 
   it('throws a validation error when invalid values are provided', () => {
     const badJson = {
       role: 'super',
-      establishmentId: 'abcd-1234',
+      establishmentId: 100,
       profileId: '1234567'
     };
-    expect(() => Permission.fromJson(badJson)).to.throw(ValidationError, /allowed values/);
+    expect(() => Invitation.fromJson(badJson)).to.throw(ValidationError, /allowed values/);
   });
 
   it('throws a validation error when unknown properties are provided', () => {
@@ -27,7 +27,7 @@ describe('Permission', () => {
       profileId: '1234567',
       unknown: 'example'
     };
-    expect(() => Permission.fromJson(badJson)).to.throw(ValidationError, /invalid additional property/);
+    expect(() => Invitation.fromJson(badJson)).to.throw(ValidationError, /invalid additional property/);
   });
 
   it('successfully instantiates when given a valid schema', () => {
@@ -36,6 +36,6 @@ describe('Permission', () => {
       establishmentId: 100,
       profileId: '1234567'
     };
-    expect(Permission.fromJson(goodJson)).to.be.an('object');
+    expect(Invitation.fromJson(goodJson)).to.be.an('object');
   });
 });

--- a/test/unit/permission.js
+++ b/test/unit/permission.js
@@ -1,23 +1,23 @@
 const expect = require('chai').expect;
-const Invitation = require('../schema/invitation');
+const Permission = require('../../schema/permission');
 const ValidationError = require('objection/lib/model/ValidationError');
 
-describe('Invitation', () => {
+describe('Permission', () => {
   it('throws a validation error when required properties are missing', () => {
     const badJson = {
-      establishmentId: 100,
+      establishmentId: 'abcd-1234',
       profileId: '1234567'
     };
-    expect(() => Invitation.fromJson(badJson)).to.throw(ValidationError, /required/);
+    expect(() => Permission.fromJson(badJson)).to.throw(ValidationError, /required/);
   });
 
   it('throws a validation error when invalid values are provided', () => {
     const badJson = {
       role: 'super',
-      establishmentId: 100,
+      establishmentId: 'abcd-1234',
       profileId: '1234567'
     };
-    expect(() => Invitation.fromJson(badJson)).to.throw(ValidationError, /allowed values/);
+    expect(() => Permission.fromJson(badJson)).to.throw(ValidationError, /allowed values/);
   });
 
   it('throws a validation error when unknown properties are provided', () => {
@@ -27,7 +27,7 @@ describe('Invitation', () => {
       profileId: '1234567',
       unknown: 'example'
     };
-    expect(() => Invitation.fromJson(badJson)).to.throw(ValidationError, /invalid additional property/);
+    expect(() => Permission.fromJson(badJson)).to.throw(ValidationError, /invalid additional property/);
   });
 
   it('successfully instantiates when given a valid schema', () => {
@@ -36,6 +36,6 @@ describe('Invitation', () => {
       establishmentId: 100,
       profileId: '1234567'
     };
-    expect(Invitation.fromJson(goodJson)).to.be.an('object');
+    expect(Permission.fromJson(goodJson)).to.be.an('object');
   });
 });

--- a/test/unit/pil.js
+++ b/test/unit/pil.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const Pil = require('../schema/pil');
+const Pil = require('../../schema/pil');
 const ValidationError = require('objection/lib/model/ValidationError');
 
 describe('Pil', () => {

--- a/test/unit/place.js
+++ b/test/unit/place.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const Place = require('../schema/place');
+const Place = require('../../schema/place');
 const ValidationError = require('objection/lib/model/ValidationError');
 
 describe('Place', () => {

--- a/test/unit/profile.js
+++ b/test/unit/profile.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const Profile = require('../schema/profile');
+const Profile = require('../../schema/profile');
 const ValidationError = require('objection/lib/model/ValidationError');
 
 describe('Profile', () => {

--- a/test/unit/project.js
+++ b/test/unit/project.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const Project = require('../schema/project');
+const Project = require('../../schema/project');
 const ValidationError = require('objection/lib/model/ValidationError');
 
 describe('Project', () => {

--- a/test/unit/role.js
+++ b/test/unit/role.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const Role = require('../schema/role');
+const Role = require('../../schema/role');
 const ValidationError = require('objection/lib/model/ValidationError');
 
 describe('Role', () => {

--- a/test/unit/validation-error.js
+++ b/test/unit/validation-error.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const ValidationError = require('../schema/validation-error');
+const ValidationError = require('../../schema/validation-error');
 const ObjectionValidationError = require('objection/lib/model/ValidationError');
 
 describe('ValidationError', () => {


### PR DESCRIPTION
The only properties on Establishment that should be required are `id` and `name`. Everything else can be provided after the initial creation.

Unfortunately knex does not support alter table on `enum` columns so I had to use raw sql.