### PR TITLE
Add database fields to handle internal permissions

### DIFF
--- a/migrations/20180927162924_asru_permissions.js
+++ b/migrations/20180927162924_asru_permissions.js
@@ -1,0 +1,18 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('profiles', table => {
+    table.boolean('asru_user').defaultsTo(false);
+    table.boolean('asru_admin').defaultsTo(false);
+    table.boolean('asru_licensing').defaultsTo(false);
+    table.boolean('asru_inspector').defaultsTo(false);
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('profiles', table => {
+    table.dropColumn('asru_user');
+    table.dropColumn('asru_admin');
+    table.dropColumn('asru_licensing');
+    table.dropColumn('asru_inspector');
+  })
+};

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -30,6 +30,10 @@ class Profile extends BaseModel {
         postcode: { type: ['string', 'null'] },
         telephone: { type: ['string', 'null'] },
         notes: { type: ['string', 'null'] },
+        'asru_user': { type: 'boolean' },
+        'asru_admin': { type: 'boolean' },
+        'asru_licensing': { type: 'boolean' },
+        'asru_inspector': { type: 'boolean' },
         'created_at': { type: 'string', format: 'date-time' },
         'updated_at': { type: 'string', format: 'date-time' },
         deleted: { type: ['string', 'null'], format: 'date-time' }


### PR DESCRIPTION
Users can be defined as being internal users, and thos internal users can be none, some or all of user admins, inspectors and licensing officers.

Adds boolean flags to profiles to reflect these states.