### PR TITLE
Add unscoped count method to establishment model

### DIFF
--- a/schema/establishment.js
+++ b/schema/establishment.js
@@ -107,6 +107,13 @@ class Establishment extends BaseModel {
     };
   }
 
+  count() {
+    return this.query()
+      .count()
+      .then(results => results[0])
+      .then(result => result.count);
+  }
+
   getPELH() {
     return this.$relatedQuery('roles')
       .where('type', 'pelh')


### PR DESCRIPTION
The default count method requires an establishment scope, which obviously doesn't make sense for establishments to be counted that way.

Extend the `count` method to be unscoped.