### PR TITLE
Add missing `static` keyword

### DIFF
--- a/schema/establishment.js
+++ b/schema/establishment.js
@@ -107,7 +107,7 @@ class Establishment extends BaseModel {
     };
   }
 
-  count() {
+  static count() {
     return this.query()
       .count()
       .then(results => results[0])


### PR DESCRIPTION
The `static` keyword is missing from the extended method in the Establishment model, so it doesn't actually extend the method.