### PR TITLE
Restore camel casing to `establishmentId` in fixture

### DIFF
--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -1,7 +1,7 @@
 [
   {
     "userId": "304cae96-0f56-492a-9f66-e99c2b3990c7",
-    "establishment_id": [8201, 8202],
+    "establishmentId": [8201, 8202],
     "title": "Dr",
     "firstName": "Leonard",
     "lastName": "Martin",


### PR DESCRIPTION
The only place this is used is expecting it to be camel cased.