### PR TITLE
Standardise user-establishment permissions in seeds

### DIFF
--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -1,7 +1,6 @@
 [
   {
     "userId": "304cae96-0f56-492a-9f66-e99c2b3990c7",
-    "establishmentId": [8201, 8202],
     "title": "Dr",
     "firstName": "Leonard",
     "lastName": "Martin",
@@ -18,6 +17,16 @@
     "roles": [
         { "establishmentId": 8201, "type": "pelh" },
         { "establishmentId": 8202, "type": "pelh" }
+    ],
+    "permissions": [
+      {
+        "establishmentId": 8201,
+        "role": "admin"
+      },
+      {
+        "establishmentId": 8202,
+        "role": "admin"
+      }
     ]
   },
   {
@@ -100,7 +109,7 @@
     "asru_licensing": true
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Cele",
     "lastName": "Siviter",
@@ -112,7 +121,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Westbrook",
     "lastName": "Otson",
@@ -124,7 +133,7 @@
     "conditions": "Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.\n\nMauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Tyson",
     "lastName": "MacArd",
@@ -136,7 +145,7 @@
     "conditions": "Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.\n\nMorbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Amii",
     "lastName": "Coffee",
@@ -148,7 +157,7 @@
     "conditions": "Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.\n\nMorbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Ignaz",
     "lastName": "Middell",
@@ -160,7 +169,7 @@
     "conditions": "Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.\n\nIn hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.\n\nAliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Andria",
     "lastName": "MacCurlye",
@@ -172,7 +181,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Aloise",
     "lastName": "Morrish",
@@ -184,7 +193,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Webb",
     "lastName": "Rieger",
@@ -196,7 +205,7 @@
     "conditions": "In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Jonah",
     "lastName": "Drewe",
@@ -208,7 +217,7 @@
     "conditions": "Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Flemming",
     "lastName": "Fishe",
@@ -220,7 +229,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Fayth",
     "lastName": "Reyna",
@@ -232,7 +241,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Andromache",
     "lastName": "Hessentaler",
@@ -244,7 +253,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Linn",
     "lastName": "Sporrij",
@@ -256,7 +265,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Ondrea",
     "lastName": "Beining",
@@ -268,7 +277,7 @@
     "conditions": "Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.\n\nSed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Reagen",
     "lastName": "Gimert",
@@ -280,7 +289,7 @@
     "conditions": "Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.\n\nCras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Kirstyn",
     "lastName": "Smallcomb",
@@ -292,7 +301,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Parnell",
     "lastName": "Stump",
@@ -304,7 +313,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Brandice",
     "lastName": "Wintersgill",
@@ -316,7 +325,7 @@
     "conditions": "Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Roberto",
     "lastName": "Patron",
@@ -328,7 +337,7 @@
     "conditions": "Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Joelly",
     "lastName": "Harbar",
@@ -340,7 +349,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Isis",
     "lastName": "May",
@@ -352,7 +361,7 @@
     "conditions": "Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Erroll",
     "lastName": "Polleye",
@@ -364,7 +373,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Jenine",
     "lastName": "Dibble",
@@ -376,7 +385,7 @@
     "conditions": "Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.\n\nDuis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.\n\nMauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Stafford",
     "lastName": "Kunz",
@@ -388,7 +397,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Mano",
     "lastName": "Yanele",
@@ -400,7 +409,7 @@
     "conditions": "In congue. Etiam justo. Etiam pretium iaculis justo.\n\nIn hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Arv",
     "lastName": "Petrillo",
@@ -412,7 +421,7 @@
     "conditions": "Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Catherina",
     "lastName": "Checkley",
@@ -424,7 +433,7 @@
     "conditions": "Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.\n\nInteger tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Ignace",
     "lastName": "Alsford",
@@ -436,7 +445,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Merry",
     "lastName": "Shovel",
@@ -448,7 +457,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Pace",
     "lastName": "Gytesham",
@@ -460,7 +469,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Consalve",
     "lastName": "Cornfoot",
@@ -472,7 +481,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Darb",
     "lastName": "Stell",
@@ -484,7 +493,7 @@
     "conditions": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Proin risus. Praesent lectus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Lonni",
     "lastName": "Dorracott",
@@ -496,7 +505,7 @@
     "conditions": "Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.\n\nEtiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.\n\nPraesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Whitby",
     "lastName": "Deare",
@@ -508,7 +517,7 @@
     "conditions": "Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.\n\nDuis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.\n\nDonec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Brucie",
     "lastName": "Attfield",
@@ -520,7 +529,7 @@
     "conditions": "Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.\n\nSed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Kata",
     "lastName": "Meneghelli",
@@ -532,7 +541,7 @@
     "conditions": "Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Jenica",
     "lastName": "Benardet",
@@ -544,7 +553,7 @@
     "conditions": "Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.\n\nCurabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Gerrie",
     "lastName": "Coggins",
@@ -556,7 +565,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Erich",
     "lastName": "Mowlam",
@@ -568,7 +577,7 @@
     "conditions": "Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.\n\nNullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.\n\nMorbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Dagny",
     "lastName": "Aberkirder",
@@ -580,7 +589,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Law",
     "lastName": "Rennox",
@@ -592,7 +601,7 @@
     "conditions": "Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.\n\nDuis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Bernice",
     "lastName": "Bricket",
@@ -604,7 +613,7 @@
     "conditions": "Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.\n\nDuis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Fabian",
     "lastName": "Petegre",
@@ -616,7 +625,7 @@
     "conditions": "Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.\n\nSed ante. Vivamus tortor. Duis mattis egestas metus.\n\nAenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Brok",
     "lastName": "Servis",
@@ -628,7 +637,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Dave",
     "lastName": "Leason",
@@ -640,7 +649,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Charisse",
     "lastName": "Higgen",
@@ -652,7 +661,7 @@
     "conditions": "Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.\n\nEtiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Laurel",
     "lastName": "Tripony",
@@ -664,7 +673,7 @@
     "conditions": "Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.\n\nVestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Ardene",
     "lastName": "covino",
@@ -676,7 +685,7 @@
     "conditions": "Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.\n\nPraesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Imojean",
     "lastName": "Addlestone",
@@ -688,7 +697,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Wood",
     "lastName": "Bagger",
@@ -700,7 +709,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Gamaliel",
     "lastName": "Wyburn",
@@ -712,7 +721,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Samara",
     "lastName": "Goulthorp",
@@ -724,7 +733,7 @@
     "conditions": "Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Mandie",
     "lastName": "Ceyssen",
@@ -736,7 +745,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Sena",
     "lastName": "Kornousek",
@@ -748,7 +757,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Kelcie",
     "lastName": "Wibrew",
@@ -760,7 +769,7 @@
     "conditions": "Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.\n\nPhasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Henrietta",
     "lastName": "Teggin",
@@ -772,7 +781,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Maire",
     "lastName": "Hanson",
@@ -784,7 +793,7 @@
     "conditions": "Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.\n\nCurabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.\n\nInteger tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Selestina",
     "lastName": "Legrice",
@@ -796,7 +805,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "firstName": "Cassondra",
     "lastName": "Aikett",
@@ -808,7 +817,7 @@
     "conditions": "Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.\n\nInteger tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.\n\nPraesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Barbee",
     "lastName": "Jewess",
@@ -820,7 +829,7 @@
     "conditions": "Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.\n\nQuisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Gillie",
     "lastName": "McAuliffe",
@@ -832,7 +841,7 @@
     "conditions": "Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Burgess",
     "lastName": "Risborough",
@@ -844,7 +853,7 @@
     "conditions": "Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Ami",
     "lastName": "Rogger",
@@ -856,7 +865,7 @@
     "conditions": "Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.\n\nCurabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Yul",
     "lastName": "Riach",
@@ -868,7 +877,7 @@
     "conditions": "In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Filippo",
     "lastName": "Gillian",
@@ -880,7 +889,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Davida",
     "lastName": "Kibbee",
@@ -892,7 +901,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Gerry",
     "lastName": "Joseland",
@@ -904,7 +913,7 @@
     "conditions": "Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Patrizio",
     "lastName": "Grigs",
@@ -916,7 +925,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Nicolea",
     "lastName": "Domini",
@@ -928,7 +937,7 @@
     "conditions": "Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.\n\nMorbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.\n\nFusce consequat. Nulla nisl. Nunc nisl."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Miss",
     "firstName": "Laurie",
     "lastName": "Stuckford",
@@ -940,7 +949,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Derek",
     "lastName": "Deschlein",
@@ -952,7 +961,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Willard",
     "lastName": "Glew",
@@ -964,7 +973,7 @@
     "conditions": "Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.\n\nCurabitur at ipsum ac tellus semper interdum. Mauris ullamcorper purus sit amet nulla. Quisque arcu libero, rutrum ac, lobortis vel, dapibus at, diam."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "firstName": "Juliann",
     "lastName": "Holson",
@@ -976,7 +985,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Honey",
     "lastName": "Raggatt",
@@ -988,7 +997,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Helen",
     "lastName": "O'Nowlan",
@@ -1000,7 +1009,7 @@
     "conditions": "Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst."
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "firstName": "Evvy",
     "lastName": "Addams",
@@ -1012,7 +1021,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Gabie",
     "lastName": "Graben",
@@ -1024,7 +1033,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Judon",
     "lastName": "Dilrew",
@@ -1036,7 +1045,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "firstName": "Alphard",
     "lastName": "Polamontayne",
@@ -1048,7 +1057,7 @@
     "conditions": ""
   },
   {
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Prof",
     "firstName": "Koren",
     "lastName": "Tollit",
@@ -1061,7 +1070,7 @@
   },
   {
     "migrated_id": 17791,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Collins",
     "firstName": "Kingsley",
@@ -1077,7 +1086,7 @@
   },
   {
     "migrated_id": 17801,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Harris",
     "firstName": "Aaron",
@@ -1093,7 +1102,7 @@
   },
   {
     "migrated_id": 17811,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Peters",
     "firstName": "Nathan",
@@ -1109,7 +1118,7 @@
   },
   {
     "migrated_id": 17831,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mrs",
     "lastName": "Jones",
     "firstName": "Lauren",
@@ -1125,7 +1134,7 @@
   },
   {
     "migrated_id": 17841,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Sharp",
     "firstName": "John",
@@ -1141,7 +1150,7 @@
   },
   {
     "migrated_id": 17861,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Ms",
     "lastName": "Alberts",
     "firstName": "Megan",
@@ -1157,7 +1166,7 @@
   },
   {
     "migrated_id": 17871,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Ayers",
     "firstName": "Ian",
@@ -1173,7 +1182,7 @@
   },
   {
     "migrated_id": 2404927,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Dr",
     "lastName": "Alden",
     "firstName": "Jason",
@@ -1189,7 +1198,7 @@
   },
   {
     "migrated_id": 2404929,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Proudfoot",
     "firstName": "Brian",
@@ -1205,7 +1214,7 @@
   },
   {
     "migrated_id": 2404930,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Patton",
     "firstName": "Benjamin",
@@ -1221,7 +1230,7 @@
   },
   {
     "migrated_id": 2404931,
-    "establishment_id": 8201,
+    "permissions": [ { "establishmentId": 8201 } ],
     "title": "Mr",
     "lastName": "Tindall",
     "firstName": "Gareth",

--- a/seeds/tables/profiles.js
+++ b/seeds/tables/profiles.js
@@ -9,7 +9,6 @@ module.exports = {
         return knex('profiles')
           .insert(omit(profile, [
             'conditions',
-            'establishment_id',
             'issue_date',
             'licence_number',
             'roles',
@@ -23,17 +22,10 @@ module.exports = {
               .then(() => {
                 if (profile.permissions) {
                   return Promise.all(profile.permissions.map(permission => knex('permissions').insert({
-                    establishmentId: permission.establishmentId,
-                    role: permission.role,
+                    ...permission,
                     profileId
                   })));
                 }
-                const est = [].concat(profile.establishmentId).filter(Boolean);
-                return Promise.all(est.map(establishmentId => knex('permissions').insert({
-                  establishmentId,
-                  profileId,
-                  role: 'admin'
-                })));
               })
               .then(() => {
                 if (!profile.licence_number) {


### PR DESCRIPTION
Instead of having two ways to achieve the same relation, just use the permissions property on a profile fixture.