### PR TITLE
Rename cat_d_notes -> notes_cat_d

### DIFF
--- a/migrations/20181008140913_rename_cat_d_notes_for_snake_mapper.js
+++ b/migrations/20181008140913_rename_cat_d_notes_for_snake_mapper.js
@@ -1,0 +1,15 @@
+// The snakeCaseMapper doesn't seem to cope with single letter uppercase so lets rearrage the words to help it
+
+exports.up = function(knex, Promise) {
+  return knex.schema.alterTable('pils', table => {
+    table.renameColumn('cat_d_notes', 'notes_cat_d');
+    table.renameColumn('cat_f_notes', 'notes_cat_f');
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.alterTable('pils', table => {
+    table.renameColumn('notes_cat_d', 'cat_d_notes');
+    table.renameColumn('notes_cat_f', 'cat_f_notes');
+  });
+};

--- a/schema/pil.js
+++ b/schema/pil.js
@@ -29,8 +29,8 @@ class PIL extends BaseModel {
           type: ['array', 'null'],
           items: { type: 'string' }
         },
-        catDNotes: { type: ['string', 'null'] },
-        catFNotes: { type: ['string', 'null'] }
+        notesCatD: { type: ['string', 'null'] },
+        notesCatF: { type: ['string', 'null'] }
       }
     };
   }

--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -118,7 +118,8 @@
     "pil": {
         "issueDate": "2015-03-20",
         "licenceNumber": "YW-052506",
-        "conditions": ""
+        "conditions": "",
+        "notesCatD": "Lorem ipsum"
     }
   },
   {

--- a/seeds/tables/profiles.js
+++ b/seeds/tables/profiles.js
@@ -30,7 +30,7 @@ module.exports = {
                   return knex('pils')
                     .insert({
                       ...profile.pil,
-                      establishment_id: profile.permissions[0].establishmentId,
+                      establishmentId: profile.permissions[0].establishmentId,
                       profileId,
                       status: 'active'
                     });


### PR DESCRIPTION
The snake case mapper is behaving ambiguously when mapping single letter upper case words, e.g. 
`catDNotes` becomes `cat_dnotes` rather than `cat_d_notes` as expected.

This PR renames it to `notes_cat_d` and `notesCatD` so that it maps correctly.