### PR TITLE
Bind models to particular knex instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { Model, knexSnakeCaseMappers } = require('objection');
+const { knexSnakeCaseMappers } = require('objection');
 const Knex = require('knex');
 const Schema = require('./schema');
 
@@ -35,10 +35,11 @@ module.exports = connection => {
   };
 
   const knex = Knex(settings);
-  Model.knex(knex);
+
+  const schema = Schema(knex);
 
   return {
-    ...Schema,
+    ...schema,
     destroy: cb => knex.destroy(cb)
   };
 };

--- a/knexfile.js
+++ b/knexfile.js
@@ -14,7 +14,7 @@ module.exports = {
     connection: {
       host: process.env.DATABASE_HOST || 'localhost',
       database: process.env.DATABASE_NAME,
-      user: process.env.DATABASE_USERNAME || 'asl-test'
+      user: process.env.DATABASE_USERNAME || 'postgres'
     }
   },
   development: {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "pretest:functional": "NODE_ENV=test npm run migrate",
     "test": "npm run test:lint && npm run test:unit && npm run test:functional",
     "test:lint": "eslint .",
-    "test:unit": "mocha ./test/unit --recursive",
-    "test:functional": "mocha ./test/functional --recursive",
+    "test:unit": "mocha ./test/unit --recursive --exit",
+    "test:functional": "mocha ./test/functional --recursive --exit",
     "migrate": "knex migrate:latest",
     "rollback": "knex migrate:rollback",
     "seed": "SNAKE_MAPPER=true knex seed:run"

--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -9,7 +9,7 @@ class SoftDeleteQueryBuilder extends Model.QueryBuilder {
     });
 
     return this.patch({
-      deleted: Model.fn().now()
+      deleted: BaseModel.fn().now()
     });
   }
 

--- a/schema/index.js
+++ b/schema/index.js
@@ -10,16 +10,16 @@ const Role = require('./role');
 const TrainingModule = require('./training-module');
 const Changelog = require('./changelog');
 
-module.exports = {
-  Authorisation,
-  Establishment,
-  Permission,
-  Invitation,
-  PIL,
-  Place,
-  Profile,
-  Project,
-  Role,
-  TrainingModule,
-  Changelog
-};
+module.exports = db => ({
+  Authorisation: Authorisation.bindKnex(db),
+  Establishment: Establishment.bindKnex(db),
+  Permission: Permission.bindKnex(db),
+  Invitation: Invitation.bindKnex(db),
+  PIL: PIL.bindKnex(db),
+  Place: Place.bindKnex(db),
+  Profile: Profile.bindKnex(db),
+  Project: Project.bindKnex(db),
+  Role: Role.bindKnex(db),
+  TrainingModule: TrainingModule.bindKnex(db),
+  Changelog: Changelog.bindKnex(db)
+});

--- a/test/functional/helpers/db.js
+++ b/test/functional/helpers/db.js
@@ -1,4 +1,6 @@
+const Knex = require('knex');
 const Schema = require('../../../');
+const BaseModel = require('../../../schema/base-model');
 const settings = require('../../../knexfile').test;
 
 const tables = [
@@ -16,7 +18,10 @@ const tables = [
 ];
 
 module.exports = {
-  init: () => Schema(settings.connection),
+  init: () => {
+    BaseModel.knex(Knex(settings));
+    return Schema(settings.connection);
+  },
   clean: schema => {
     return tables.reduce((p, table) => {
       return p.then(() => schema[table].queryWithDeleted().hardDelete());

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,10 +1,11 @@
 const assert = require('assert');
-const Schema = require('../../schema');
+const Schema = require('../../');
 
 describe('Schema', () => {
 
   it('can initialise without error', () => {
-    assert.equal(typeof Schema, 'object');
+    assert.equal(typeof Schema, 'function');
+    assert.doesNotThrow(() => Schema({}));
   });
 
 });


### PR DESCRIPTION
By calling `bindKnex` only on particular models, and not using the global objection `knex` method to bind all possible models we allow the use of different database configuration for different objection models.