### PR TITLE
Call `now` function directly on knex instance

### DIFF
--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -9,7 +9,7 @@ class SoftDeleteQueryBuilder extends Model.QueryBuilder {
     });
 
     return this.patch({
-      deleted: BaseModel.fn().now()
+      deleted: this.knex().fn.now()
     });
   }
 

--- a/test/functional/base-model.js
+++ b/test/functional/base-model.js
@@ -1,5 +1,7 @@
 const moment = require('moment');
 const assert = require('assert');
+const Knex = require('knex');
+const settings = require('../../knexfile').test;
 const db = require('./helpers/db');
 const BaseModel = require('../../schema/base-model');
 
@@ -15,8 +17,8 @@ describe('Base Model', () => {
           return 'authorisations';
         }
       }
-      this.Model = Model;
       this.db = db.init();
+      this.Model = Model.bindKnex(Knex(settings));
     });
 
     beforeEach(() => {

--- a/test/functional/helpers/db.js
+++ b/test/functional/helpers/db.js
@@ -1,6 +1,4 @@
-const Knex = require('knex');
 const Schema = require('../../../');
-const BaseModel = require('../../../schema/base-model');
 const settings = require('../../../knexfile').test;
 
 const tables = [
@@ -18,10 +16,7 @@ const tables = [
 ];
 
 module.exports = {
-  init: () => {
-    BaseModel.knex(Knex(settings));
-    return Schema(settings.connection);
-  },
+  init: () => Schema(settings.connection),
   clean: schema => {
     return tables.reduce((p, table) => {
       return p.then(() => schema[table].queryWithDeleted().hardDelete());


### PR DESCRIPTION
This requires only that the particular model in question has been bound to a knex instance, and not - as before - that the `BaseModel` itself had been bound to a knex.