### PR TITLE
Prevent assignment of projects to the basic user

### DIFF
--- a/seeds/tables/projects.js
+++ b/seeds/tables/projects.js
@@ -5,12 +5,15 @@ module.exports = {
   populate: knex => {
     return Promise.all(
       projects.filter(p => !p.id).map(project => {
-        return knex('profiles').then(profiles => {
-          return knex('projects').insert({
-            licenceHolderId: sample(profiles).id,
-            ...project
+        return knex('profiles')
+          .where('firstName', '!=', 'Basic')
+          .then(profiles => {
+            return knex('projects')
+              .insert({
+                licenceHolderId: sample(profiles).id,
+                ...project
+              });
           });
-        });
       })
     );
   },


### PR DESCRIPTION
The assignment of projet licence holders was totally random, which mean that occasionally the basic user would be assigned one. This caused an integration test that checked that a basic user only had one project to fail.

This doesn't make it any less random, but at least prevents _that_ user being assigned more projects.