### PR TITLE
Add connection pool configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ module.exports = connection => {
     client: 'pg',
     useNullAsDefault: true,
     connection,
+    pool: { min: 1, max: 5 },
     ...knexSnakeCaseMappers()
   };
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -15,6 +15,10 @@ module.exports = {
       host: process.env.DATABASE_HOST || 'localhost',
       database: process.env.DATABASE_NAME,
       user: process.env.DATABASE_USERNAME || 'postgres'
+    },
+    pool: {
+      min: 1,
+      max: 2
     }
   },
   development: {
@@ -26,6 +30,10 @@ module.exports = {
       port: process.env.DATABASE_PORT,
       user: process.env.DATABASE_USERNAME || 'postgres',
       password: process.env.DATABASE_PASSWORD
+    },
+    pool: {
+      min: 1,
+      max: 2
     }
   }
 };


### PR DESCRIPTION
Scales back slightly the default values of `{ min: 2, max: 10 }` to use slightly fewer connections when scaled across mutliple clients, and reduce the probability of exhausting the global connection limits.