### PR TITLE
Expose transaction function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { knexSnakeCaseMappers } = require('objection');
+const { knexSnakeCaseMappers, transaction } = require('objection');
 const Knex = require('knex');
 const Schema = require('./schema');
 
@@ -41,6 +41,7 @@ module.exports = connection => {
 
   return {
     ...schema,
+    transaction: () => transaction.start(knex),
     destroy: cb => knex.destroy(cb)
   };
 };


### PR DESCRIPTION
Starting a transaction requires access to the `knex` instance, which is not exposed. Expose the transaction function to shorthand this.