### PR TITLE
Add relation mapping from an invitation to an establishment

### DIFF
--- a/schema/invitation.js
+++ b/schema/invitation.js
@@ -54,6 +54,20 @@ class Invitation extends BaseModel {
 
     return query;
   }
+
+  static get relationMappings() {
+    return {
+      establishment: {
+        relation: this.BelongsToOneRelation,
+        modelClass: `${__dirname}/establishment`,
+        join: {
+          from: 'invitations.establishmentId',
+          to: 'establishments.id'
+        }
+      }
+    };
+  }
+
 }
 
 module.exports = Invitation;


### PR DESCRIPTION
This allows the inclusion of the establishment name when retrieving the invitations for a user.