### PR TITLE
Add a pretend role of 'admin' to the people query roles filter

### DIFF
--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -26,10 +26,16 @@ class SoftDeleteQueryBuilder extends Model.QueryBuilder {
     return super.delete();
   }
 
-  scopeToEstablishment(column, establishmentId) {
-    return this.mergeContext({ establishmentId })
+  scopeToEstablishment(column, establishmentId, role) {
+    const query = this.mergeContext({ establishmentId })
       .joinRelation('establishments')
       .where(column, establishmentId);
+
+    if (role) {
+      query.where({ role });
+    }
+
+    return query;
   }
 }
 

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -133,9 +133,11 @@ class Profile extends BaseModel {
   }) {
     query = query || this.query();
 
+    const role = filters.roles && filters.roles.includes('admin') ? 'admin' : null;
+
     query
       .distinct('profiles.*', 'pil.licenceNumber')
-      .scopeToEstablishment('establishments.id', establishmentId)
+      .scopeToEstablishment('establishments.id', establishmentId, role)
       .leftJoinRelation('[pil, projects, roles]')
       .eager('[pil, projects, establishments, roles]')
       .where(builder => {
@@ -148,8 +150,9 @@ class Profile extends BaseModel {
 
     if (filters.roles && filters.roles.length) {
       const roles = compact(filters.roles);
+
       // filter on pseudo roles
-      const customRoles = remove(roles, role => role === 'pilh' || role === 'pplh');
+      const customRoles = remove(roles, role => ['pplh', 'pilh', 'admin'].includes(role));
 
       if (roles.length) {
         query.whereIn('roles.type', roles);


### PR DESCRIPTION
The query parameter needs to be added to the `scopeToEstablishment` call because it needs to be a condition on that join, and ading it separately throws an error about a join being defined twice.