### PR TITLE
Set project status in seed data

### DIFF
--- a/seeds/data/projects.json
+++ b/seeds/data/projects.json
@@ -26,7 +26,8 @@
     "title": "Search for the luminescent aether",
     "issueDate": "2016-02-05",
     "expiryDate": "2018-03-01",
-    "licenceNumber": "PR-764848"
+    "licenceNumber": "PR-764848",
+    "status": "expired"
   },
   {
     "id": "f638b9b2-e11b-477a-84f9-fd6755f428c3",
@@ -34,7 +35,8 @@
     "title": "Evaluation of novel anti-cancer agents",
     "issueDate": "2016-02-05",
     "expiryDate": "2018-07-01",
-    "licenceNumber": "PR-250436"
+    "licenceNumber": "PR-250436",
+    "status": "expired"
   },
   {
     "id": "a09937d7-6c05-4dea-bd5f-3ba8168875cb",
@@ -42,7 +44,8 @@
     "title": "Development of new biological anti-cancer agents",
     "issueDate": "2017-10-01",
     "expiryDate": "2018-08-01",
-    "licenceNumber": "PR-890458"
+    "licenceNumber": "PR-890458",
+    "status": "expired"
   },
   {
     "id": "7828ae88-68a8-404b-ab53-ff1077722f07",
@@ -50,7 +53,8 @@
     "title": "Thermosensitive nanoparticles for cancer therapy",
     "issueDate": "2015-11-24",
     "expiryDate": "2018-09-01",
-    "licenceNumber": "PR-192985"
+    "licenceNumber": "PR-192985",
+    "status": "expired"
   },
   {
     "id": "b8b28a7b-3157-41c8-ae3f-7baf33085e8d",
@@ -58,7 +62,8 @@
     "title": "Oncolytic HSV as an anti-cancer therapy",
     "issueDate": "2018-02-24",
     "expiryDate": "2018-10-01",
-    "licenceNumber": "PR-278783"
+    "licenceNumber": "PR-278783",
+    "status": "expired"
   },
   {
     "id": "c2334f4e-f8ce-4fb6-a726-5f87ee26da55",
@@ -66,7 +71,8 @@
     "title": "Hypoxy and angiogenesis in cancer therapy",
     "issueDate": "2017-04-23",
     "expiryDate": "2018-11-01",
-    "licenceNumber": "PR-671216"
+    "licenceNumber": "PR-671216",
+    "status": "expired"
   },
   {
     "id": "5a1ad546-f347-4f65-b905-595d64932da2",
@@ -74,7 +80,8 @@
     "title": "Evaluation of novel anti-cancer agents",
     "issueDate": "2016-02-05",
     "expiryDate": "2018-12-01",
-    "licenceNumber": "PR-050381"
+    "licenceNumber": "PR-050381",
+    "status": "expired"
   },
   {
     "id": "ce80a27b-054c-4264-a60b-469a67413d73",
@@ -82,7 +89,8 @@
     "title": "Development of new biological anti-cancer agents",
     "issueDate": "2017-10-01",
     "expiryDate": "2019-01-01",
-    "licenceNumber": "PR-787013"
+    "licenceNumber": "PR-787013",
+    "status": "expired"
   },
   {
     "id": "8b946810-e202-412d-95ba-d9473fc600d3",
@@ -90,7 +98,8 @@
     "title": "Thermosensitive nanoparticles for cancer therapy",
     "issueDate": "2015-11-24",
     "expiryDate": "2019-02-01",
-    "licenceNumber": "PR-519417"
+    "licenceNumber": "PR-519417",
+    "status": "expired"
   },
   {
     "id": "7f28e0d2-3431-4b4b-bf77-3652f1968c5d",
@@ -98,7 +107,8 @@
     "title": "Oncolytic HSV as an anti-cancer therapy",
     "issueDate": "2018-02-24",
     "expiryDate": "2019-03-01",
-    "licenceNumber": "PR-265039"
+    "licenceNumber": "PR-265039",
+    "status": "expired"
   },
   {
     "id": "4e3241d6-5725-489f-bdf9-8b688a7a85c7",
@@ -106,7 +116,8 @@
     "title": "Hypoxy and angiogenesis in cancer therapy",
     "issueDate": "2017-04-23",
     "expiryDate": "2019-04-01",
-    "licenceNumber": "PR-127482"
+    "licenceNumber": "PR-127482",
+    "status": "expired"
   },
   {
     "id": "01a55d81-76b7-42eb-957e-c31d69da52d4",
@@ -114,7 +125,8 @@
     "title": "Evaluation of novel anti-cancer agents",
     "issueDate": "2016-02-05",
     "expiryDate": "2019-05-01",
-    "licenceNumber": "PR-635078"
+    "licenceNumber": "PR-635078",
+    "status": "expired"
   },
   {
     "id": "f05b13d5-de41-4173-b313-cd165c8f8072",
@@ -122,7 +134,8 @@
     "title": "Development of new biological anti-cancer agents",
     "issueDate": "2017-10-01",
     "expiryDate": "2019-06-01",
-    "licenceNumber": "PR-141529"
+    "licenceNumber": "PR-141529",
+    "status": "expired"
   },
   {
     "id": "e15b1645-730e-40ea-a177-7fee4ab757cb",
@@ -130,7 +143,8 @@
     "title": "Thermosensitive nanoparticles for cancer therapy",
     "issueDate": "2015-11-24",
     "expiryDate": "2019-07-01",
-    "licenceNumber": "PR-377835"
+    "licenceNumber": "PR-377835",
+    "status": "active"
   },
   {
     "id": "6d2c6e8c-d38f-48b5-806b-ac698e5d4f6e",
@@ -138,7 +152,8 @@
     "title": "Oncolytic HSV as an anti-cancer therapy",
     "issueDate": "2018-02-24",
     "expiryDate": "2019-08-01",
-    "licenceNumber": "PR-474098"
+    "licenceNumber": "PR-474098",
+    "status": "active"
   },
   {
     "id": "09971443-dfcb-483d-88f7-d0bacbbf4d76",
@@ -146,7 +161,8 @@
     "title": "Hypoxy and angiogenesis in cancer therapy",
     "issueDate": "2017-04-23",
     "expiryDate": "2019-09-01",
-    "licenceNumber": "PR-627808"
+    "licenceNumber": "PR-627808",
+    "status": "active"
   },
   {
     "id": "6a651f3b-fa06-460f-a321-147b4002e20a",
@@ -154,7 +170,8 @@
     "title": "Evaluation of novel anti-cancer agents",
     "issueDate": "2016-02-05",
     "expiryDate": "2019-10-01",
-    "licenceNumber": "PR-398957"
+    "licenceNumber": "PR-398957",
+    "status": "active"
   },
   {
     "id": "3dfbaca9-8ff4-4509-b0ef-763b6a31b2ac",
@@ -162,7 +179,8 @@
     "title": "Development of new biological anti-cancer agents",
     "issueDate": "2017-10-01",
     "expiryDate": "2019-11-01",
-    "licenceNumber": "PR-404484"
+    "licenceNumber": "PR-404484",
+    "status": "active"
   },
   {
     "id": "855d6a51-338d-4c81-ae6f-d2dc89674c66",
@@ -170,7 +188,8 @@
     "title": "Thermosensitive nanoparticles for cancer therapy",
     "issueDate": "2015-11-24",
     "expiryDate": "2019-12-01",
-    "licenceNumber": "PR-374785"
+    "licenceNumber": "PR-374785",
+    "status": "active"
   },
   {
     "id": "2319e33e-ffa0-4197-bb92-26a38c18662e",
@@ -178,7 +197,8 @@
     "title": "Oncolytic HSV as an anti-cancer therapy",
     "issueDate": "2018-02-24",
     "expiryDate": "2020-01-01",
-    "licenceNumber": "PR-439411"
+    "licenceNumber": "PR-439411",
+    "status": "active"
   },
   {
     "id": "d42196ff-eb93-4b20-8b71-22673901873d",
@@ -186,6 +206,7 @@
     "title": "Hypoxy and angiogenesis in cancer therapy",
     "issueDate": "2017-04-23",
     "expiryDate": "2020-03-01",
-    "licenceNumber": "PR-670832"
+    "licenceNumber": "PR-670832",
+    "status": "active"
   }
 ]


### PR DESCRIPTION
Make sure all the seed projects have appropriate statuses, otherwise they default to `inactive` which makes things behave weirdly because they also have issue dates and expiry dates.