### PR TITLE
Prevent the "readonly" user being assigned projects

### DIFF
--- a/seeds/tables/projects.js
+++ b/seeds/tables/projects.js
@@ -6,7 +6,7 @@ module.exports = {
     return Promise.all(
       projects.filter(p => !p.licenceHolderId).map(project => {
         return knex('profiles')
-          .where('firstName', '!=', 'Basic')
+          .whereNotIn('firstName', ['Basic', 'Read'])
           .andWhere('asruUser', false)
           .then(profiles => {
             return knex('projects')
@@ -24,7 +24,7 @@ module.exports = {
     return Promise.all(
       projectsList.map(project => {
         return knex('profiles')
-          .where('firstName', '!=', 'Basic')
+          .whereNotIn('firstName', ['Basic', 'Read'])
           .andWhere('asruUser', false)
           .first()
           .then(profile => {


### PR DESCRIPTION
Some of the integration tests rely on that user not having any roles or licences assigned, so make sure that this is the case.