### PR TITLE
Use correct command to run container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . /app
 
 RUN rm /app/.npmrc
 
-CMD node index.js
+CMD npm run migrate & ./keepalive.sh


### PR DESCRIPTION
This got broken when I was converting images to use the base image and got too copy-paste happy to remember this isn't a conventional web service.