### PR TITLE
Authorisation records will break the seeds due to fk constraints

### DIFF
--- a/seeds/index.js
+++ b/seeds/index.js
@@ -13,6 +13,7 @@ exports.seed = knex => {
     .then(() => knex('certificates').del())
     .then(() => knex('exemptions').del())
     .then(() => profiles.delete(knex))
+    .then(() => knex('authorisations').del())
     .then(() => establishments.delete(knex))
 
     .then(() => establishments.populate(knex))


### PR DESCRIPTION
Having any authorisations present in the dev db will prevent the seeds running successfully.