### PR TITLE
Fix wildcard matching in people search

### DIFF
--- a/schema/profile.js
+++ b/schema/profile.js
@@ -113,7 +113,7 @@ class Profile extends BaseModel {
     }
     if (parts.length > 1) {
       query
-        .where(firstName, 'iLike', `%${parts[0]}`)
+        .where(firstName, 'iLike', `${parts[0]}%`)
         .andWhere(lastName, 'iLike', `${parts[1]}%`);
     } else {
       query

--- a/test/functional/profile.js
+++ b/test/functional/profile.js
@@ -117,7 +117,7 @@ describe('Profile model', () => {
     it('can search on full name', () => {
       const opts = {
         establishmentId: 8201,
-        search: 'cent mal'
+        search: 'vinc mal'
       };
       return Promise.resolve()
         .then(() => this.models.Profile.searchAndFilter(opts))


### PR DESCRIPTION
The wildcard for the first name was at the beginning so it would only match the end of a first name.

e.g. `Dagny Aberkirder` was matching a search for `y aberkirder` but not `d aberkirder` - which is weird and counterintuitive

Move the wildcard to the end so partial matches always match from the beginning of the name.