### PR TITLE
Remove PIL from profile list distinct clause

### DIFF
--- a/schema/profile.js
+++ b/schema/profile.js
@@ -136,7 +136,7 @@ class Profile extends BaseModel {
     const role = filters.roles && filters.roles.includes('admin') ? 'admin' : null;
 
     query
-      .distinct('profiles.*', 'pil.licenceNumber')
+      .distinct('profiles.*')
       .scopeToEstablishment('establishments.id', establishmentId, role)
       .leftJoinRelation('[pil, projects, roles]')
       .eager('[pil, projects, establishments, roles]')


### PR DESCRIPTION
This was causing the same profile to be returned multiple times if they had more than one PIL. Remove the PIL from the distinct clause on the query so that each profile is returned exactly once.