### PR TITLE
Add a project with legacy list formatting

### DIFF
--- a/seeds/data/project-versions.json
+++ b/seeds/data/project-versions.json
@@ -346,5 +346,13 @@
       "title": "Amend in prog project 2"
     },
     "status": "submitted"
+  },
+  {
+    "projectId": "6b9b7471-396e-47fe-a98f-da0c76e0a26b",
+    "data": {
+      "title": "Project with legacy list",
+      "project-aim": "{\"object\":\"value\",\"document\":{\"object\":\"document\",\"data\":{},\"nodes\":[{\"object\":\"block\",\"type\":\"bulleted-list\",\"nodes\":[{\"object\":\"block\",\"type\":\"list-item\",\"nodes\":[{\"object\":\"text\",\"text\":\"List item 1\",\"marks\":[]}],\"data\":{}},{\"object\":\"block\",\"type\":\"list-item\",\"nodes\":[{\"object\":\"text\",\"text\":\"List item 2\",\"marks\":[]}],\"data\":{}}],\"data\":{}}]}}"
+    },
+    "status": "granted"
   }
 ]

--- a/seeds/data/projects.json
+++ b/seeds/data/projects.json
@@ -256,5 +256,15 @@
     "licenceNumber": "PR-X00002",
     "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd",
     "status": "active"
+  },
+  {
+    "id": "6b9b7471-396e-47fe-a98f-da0c76e0a26b",
+    "establishmentId": 8201,
+    "title": "Project with legacy list",
+    "issueDate": "2019-04-23",
+    "expiryDate": "2024-04-23",
+    "licenceNumber": "PR-X00003",
+    "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd",
+    "status": "active"
   }
 ]


### PR DESCRIPTION
Old rich-text-editor lists didn't wrap their child nodes in a `paragraph` and so don't currently render correctly in Word downloads.