### PR TITLE
Check version status is explicitly not draft for filtering unsubmitted

### DIFF
--- a/schema/project.js
+++ b/schema/project.js
@@ -81,7 +81,7 @@ class Project extends BaseModel {
 
   static filterUnsubmittedDrafts(query) {
     return query.joinRelation('version')
-      .where('version.status', 'submitted');
+      .where('version.status', '!=', 'draft');
   }
 
   static count({ query, establishmentId, status, isAsru }) {


### PR DESCRIPTION
Projects with versions of status `granted` should also be included.