### PR TITLE
Add secondary sort when sorting places

### DIFF
--- a/schema/place.js
+++ b/schema/place.js
@@ -80,11 +80,10 @@ class Place extends BaseModel {
 
     if (sort.column) {
       query = this.orderBy({ query, sort });
-    } else {
-      query.orderBy('site')
-        .orderBy('area')
-        .orderBy('name');
     }
+    query.orderBy('site')
+      .orderBy('area')
+      .orderBy('name');
 
     query = this.paginate({ query, limit, offset });
 


### PR DESCRIPTION
Always sort places by site, area and name after any specified sort order.

For example, if sorting by NACWO, then within each NACWO's results the entries will always be ordered logically.