### PR TITLE
Add a second establishment to a user with a PIL

### DIFF
--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -502,6 +502,9 @@
     "permissions": [
       {
         "establishmentId": 8201
+      },
+      {
+        "establishmentId": 8202
       }
     ],
     "title": "Ms",
@@ -511,6 +514,7 @@
     "email": "pstumpg@example.com",
     "telephone": 8671852914,
     "pil": {
+      "status": "active",
       "issueDate": "2017-04-19",
       "licenceNumber": "PX-055736",
       "conditions": ""


### PR DESCRIPTION
To allow testing removal of permissions at non-PIL-holding establishments