### PR TITLE
Add distinct clause to counts

### DIFF
--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -65,9 +65,9 @@ class BaseModel extends Model {
   static count(establishmentId) {
     return this.query()
       .where({ establishmentId })
-      .count()
+      .countDistinct(`${this.tableName}.id`)
       .then(results => results[0])
-      .then(result => result.count);
+      .then(result => parseInt(result.count, 10));
   }
 
   static upsert(model, where, transaction) {

--- a/schema/establishment.js
+++ b/schema/establishment.js
@@ -122,9 +122,9 @@ class Establishment extends BaseModel {
 
   static count() {
     return this.query()
-      .count()
+      .countDistinct('establishments.id')
       .then(results => results[0])
-      .then(result => result.count);
+      .then(result => parseInt(result.count, 10));
   }
 }
 

--- a/schema/invitation.js
+++ b/schema/invitation.js
@@ -38,7 +38,7 @@ class Invitation extends BaseModel {
       .where({ establishmentId })
       .count()
       .then(results => results[0])
-      .then(result => result.count);
+      .then(result => parseInt(result.count, 10));
   }
 
   static paginate({ establishmentId, sort = {}, limit, offset }) {

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -99,8 +99,9 @@ class Profile extends BaseModel {
 
     return query
       .scopeToEstablishment('establishments.id', establishmentId)
-      .count()
-      .then(result => result[0].count);
+      .countDistinct('profiles.id')
+      .then(result => result[0])
+      .then(result => parseInt(result.count, 10));
   }
 
   static searchFullName({ query, search, prefix }) {

--- a/schema/project.js
+++ b/schema/project.js
@@ -94,8 +94,9 @@ class Project extends BaseModel {
     return query
       .where({ establishmentId })
       .where('projects.status', status)
-      .count()
-      .then(result => result[0].count);
+      .countDistinct('projects.id')
+      .then(result => result[0])
+      .then(result => parseInt(result.count, 10));
   }
 
   static search({ query, establishmentId, search, status = 'active', sort = {}, limit, offset, isAsru }) {


### PR DESCRIPTION
To prevent projects with multiple versions being counted multiple times.

Also wraps the response to all count queries in a `parseInt` call to ensure counts are always integers and not strings as is the (silly) default.