### PR TITLE
Allow container to fail if migration does not run successfully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . /app
 
 RUN rm /app/.npmrc
 
-CMD npm run migrate & ./keepalive.sh
+CMD npm run migrate && ./keepalive.sh


### PR DESCRIPTION
If the migration fails then the pod should not run, and the associated deployment should fail.