### PR TITLE
Set `ntco` user to basic permissions at two establishments

### DIFF
--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -56,7 +56,11 @@
     "permissions": [
       {
         "establishmentId": 8201,
-        "role": "read"
+        "role": "basic"
+      },
+      {
+        "establishmentId": 8202,
+        "role": "basic"
       }
     ]
   },


### PR DESCRIPTION
To facilitate testing enhanced NTCO permission levels