### PR TITLE
Add billable query method to PIL model

### DIFF
--- a/schema/pil.js
+++ b/schema/pil.js
@@ -1,8 +1,73 @@
+const { QueryBuilder } = require('objection');
 const BaseModel = require('./base-model');
 const { pilStatuses } = require('@asl/constants');
 const { uuid } = require('../lib/regex-validation');
 
+class PILQueryBuilder extends QueryBuilder {
+
+  billable({ establishmentId, start, end }) {
+    return this
+      .select('pils.id', 'pils.licenceNumber', 'pils.establishmentId', 'pils.issueDate', 'pils.revocationDate')
+      .eager('[profile.establishments, pilTransfers]')
+      .leftJoinRelation('profile')
+      .where(builder => {
+        // PIL was active during billing period
+        builder
+          .where('issueDate', '<=', end)
+          .whereNotNull('issueDate')
+          .where(builder => {
+            builder
+              .whereNull('revocationDate')
+              .orWhere('revocationDate', '>', start);
+          });
+      })
+      .where(builder => {
+        builder
+          // PIL is currently held by establishment and has not been transferred in since end date
+          .where(builder => {
+            builder
+              .where({ 'establishmentId': establishmentId })
+              .whereNotExists(
+                PIL.relatedQuery('pilTransfers')
+                  .where('createdAt', '>', end)
+              );
+          })
+          // PIL was transferred in or out of the establishment during the billing period
+          .orWhere(builder => {
+            builder
+              .whereExists(
+                PIL.relatedQuery('pilTransfers')
+                  .where(builder => {
+                    builder
+                      .where('fromEstablishmentId', establishmentId)
+                      .orWhere('toEstablishmentId', establishmentId);
+                  })
+                  .whereBetween('createdAt', [start, end])
+              );
+          })
+          // the first PIL transfer after the end of the billing period was out of the establishment
+          .orWhere(builder => {
+            builder
+              .where(
+                establishmentId,
+                PIL.relatedQuery('pilTransfers')
+                  .select('fromEstablishmentId')
+                  .where('createdAt', '>', end)
+                  .orderBy('createdAt', 'asc')
+                  .limit(1)
+              );
+          });
+      });
+  }
+
+}
+
 class PIL extends BaseModel {
+
+  static get QueryBuilder() {
+    return PILQueryBuilder;
+  }
+
   static get tableName() {
     return 'pils';
   }
@@ -50,7 +115,7 @@ class PIL extends BaseModel {
           to: 'establishments.id'
         }
       },
-      transfers: {
+      pilTransfers: {
         relation: this.HasManyRelation,
         modelClass: `${__dirname}/pil-transfer`,
         join: {

--- a/schema/pil.js
+++ b/schema/pil.js
@@ -1,9 +1,8 @@
-const { QueryBuilder } = require('objection');
 const BaseModel = require('./base-model');
 const { pilStatuses } = require('@asl/constants');
 const { uuid } = require('../lib/regex-validation');
 
-class PILQueryBuilder extends QueryBuilder {
+class PILQueryBuilder extends BaseModel.QueryBuilder {
 
   billable({ establishmentId, start, end }) {
     return this

--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -495,7 +495,19 @@
     "pil": {
       "issueDate": "2016-02-02",
       "licenceNumber": "SG-812779",
-      "conditions": ""
+      "conditions": "",
+      "transfers": [
+        {
+          "fromEstablishmentId": 8202,
+          "toEstablishmentId": 10001,
+          "createdAt": "2019-04-08"
+        },
+        {
+          "fromEstablishmentId": 10001,
+          "toEstablishmentId": 8201,
+          "createdAt": "2019-04-09"
+        }
+      ]
     }
   },
   {
@@ -1026,7 +1038,24 @@
       {
         "issueDate": "2015-11-06",
         "licenceNumber": "SN-682317",
-        "conditions": ""
+        "conditions": "",
+        "transfers": [
+          {
+            "fromEstablishmentId": 10001,
+            "toEstablishmentId": 8202,
+            "createdAt": "2018-04-04"
+          },
+          {
+            "fromEstablishmentId": 8202,
+            "toEstablishmentId": 10001,
+            "createdAt": "2019-04-08"
+          },
+          {
+            "fromEstablishmentId": 10001,
+            "toEstablishmentId": 8201,
+            "createdAt": "2019-04-09"
+          }
+        ]
       },
       {
         "status": "revoked",
@@ -1199,7 +1228,7 @@
     "email": "iaddlestone1c@example.com",
     "telephone": 8472990993,
     "pil": {
-      "issueDate": "2018-04-03",
+      "issueDate": "2019-04-09",
       "licenceNumber": "MA-722085",
       "conditions": ""
     }

--- a/seeds/tables/profiles.js
+++ b/seeds/tables/profiles.js
@@ -77,7 +77,7 @@ module.exports = {
                                   pilId
                                 });
                               });
-                          }, Promise.resolve())
+                          }, Promise.resolve());
                         }
                       });
                   }, Promise.resolve());

--- a/seeds/tables/profiles.js
+++ b/seeds/tables/profiles.js
@@ -62,10 +62,23 @@ module.exports = {
                           notesCatF,
                           profileId,
                           establishmentId: profile.permissions[0].establishmentId,
-                          ...pil,
+                          ...omit(pil, 'transfers'),
                           procedures: JSON.stringify(procedures),
                           species: JSON.stringify(pil.species)
-                        });
+                        }).returning('id');
+                      })
+                      .then(([ pilId ]) => {
+                        if (pil.transfers) {
+                          pil.transfers.reduce((promise, transfer) => {
+                            return promise
+                              .then(() => {
+                                return knex('pil_transfers').insert({
+                                  ...transfer,
+                                  pilId
+                                });
+                              });
+                          }, Promise.resolve())
+                        }
                       });
                   }, Promise.resolve());
                 }

--- a/test/functional/helpers/db.js
+++ b/test/functional/helpers/db.js
@@ -8,6 +8,7 @@ const tables = [
   'Permission',
   'Invitation',
   'Authorisation',
+  'PilTransfer',
   'PIL',
   'Place',
   'Role',

--- a/test/functional/pil.js
+++ b/test/functional/pil.js
@@ -1,0 +1,178 @@
+const assert = require('assert');
+const db = require('./helpers/db');
+
+describe('PIL model', () => {
+
+  before(() => {
+    return Promise.resolve()
+      .then(() => {
+        this.models = db.init();
+      })
+      .then(() => db.clean(this.models));
+  });
+
+  after(() => {
+    return db.clean(this.models)
+      .then(() => this.models.destroy());
+  });
+
+  describe('billable', () => {
+
+    before(() => {
+      return this.models.Establishment.query().insertGraph([
+        {
+          id: 100,
+          name: 'Establishment 1'
+        },
+        {
+          id: 101,
+          name: 'Establishment 2'
+        },
+        {
+          id: 102,
+          name: 'Establishment 3',
+          profiles: [
+            {
+              firstName: 'Active',
+              lastName: 'Pil',
+              email: 'activepil@example.com',
+              pil: {
+                establishmentId: 102,
+                procedures: ['A'],
+                status: 'active',
+                issueDate: '2018-01-01T12:00:00Z'
+              }
+            },
+            {
+              firstName: 'Revoked',
+              lastName: 'Pil',
+              email: 'revokedpil@example.com',
+              pil: {
+                establishmentId: 102,
+                procedures: ['A'],
+                status: 'revoked',
+                issueDate: '2018-01-01T12:00:00Z',
+                revocationDate: '2018-02-01T12:00:00Z'
+              }
+            },
+            {
+              firstName: 'Transfered',
+              lastName: 'Pil',
+              email: 'transferedpil@example.com',
+              pil: {
+                establishmentId: 102,
+                procedures: ['A'],
+                status: 'active',
+                issueDate: '2018-01-01T12:00:00Z',
+                pilTransfers: [
+                  {
+                    fromEstablishmentId: 101,
+                    toEstablishmentId: 102,
+                    createdAt: '2019-05-01T12:00:00Z'
+                  }
+                ]
+              }
+            },
+            {
+              firstName: 'Multiple',
+              lastName: 'Transfers',
+              email: 'manytransfers@example.com',
+              pil: {
+                establishmentId: 102,
+                procedures: ['A'],
+                status: 'active',
+                issueDate: '2016-01-01T12:00:00Z',
+                pilTransfers: [
+                  {
+                    fromEstablishmentId: 102,
+                    toEstablishmentId: 101,
+                    createdAt: '2016-03-01T12:00:00Z'
+                  },
+                  {
+                    fromEstablishmentId: 101,
+                    toEstablishmentId: 100,
+                    createdAt: '2018-06-01T12:00:00Z'
+                  },
+                  {
+                    fromEstablishmentId: 100,
+                    toEstablishmentId: 101,
+                    createdAt: '2019-04-01T12:00:00Z'
+                  },
+                  {
+                    fromEstablishmentId: 101,
+                    toEstablishmentId: 102,
+                    createdAt: '2019-05-01T12:00:00Z'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]);
+    });
+
+    const isBillable = (results, email) => {
+      const emails = results.map(pil => pil.profile.email);
+      assert.ok(emails.includes(email), `Billable PIL list should contain PIL for ${email}`);
+      return results;
+    };
+
+    const isNotBillable = (results, email) => {
+      const emails = results.map(pil => pil.profile.email);
+      assert.ok(!emails.includes(email), `Billable PIL list should not contain PIL for ${email}`);
+      return results;
+    };
+
+    it('exposes a `billable` query method', () => {
+      const { PIL } = this.models;
+      return assert.equal(typeof PIL.query().billable, 'function');
+    });
+
+    it('includes PILs which were valid in the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 102, start: '2018-04-06', end: '2019-04-05' })
+        .then(results => isBillable(results, 'activepil@example.com'));
+    });
+
+    it('does not include PILs which were revoked before the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 102, start: '2018-04-06', end: '2019-04-05' })
+        .then(results => isNotBillable(results, 'revokedpil@example.com'));
+    });
+
+    it('does not include PILs which were granted after the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 102, start: '2016-04-06', end: '2017-04-05' })
+        .then(results => isNotBillable(results, 'activepil@example.com'));
+    });
+
+    it('does not include PILs which were transfered into the establishment after the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 102, start: '2018-04-06', end: '2019-04-05' })
+        .then(results => isNotBillable(results, 'transferedpil@example.com'));
+    });
+
+    it('includes PILs which were transfered out of the establishment after the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 101, start: '2018-04-06', end: '2019-04-05' })
+        .then(results => isBillable(results, 'transferedpil@example.com'));
+    });
+
+    it('includes PILs which were transferred out of the establishment during the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 101, start: '2019-04-06', end: '2020-04-05' })
+        .then(results => isBillable(results, 'transferedpil@example.com'));
+    });
+
+    it('includes PILs which were transferred in and out of the establishment during the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 100, start: '2018-04-06', end: '2019-04-05' })
+        .then(results => isBillable(results, 'manytransfers@example.com'));
+    });
+
+    it('includes PILs which were transferred in and out of the establishment either side the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 101, start: '2017-04-06', end: '2018-04-05' })
+        .then(results => isBillable(results, 'manytransfers@example.com'));
+    });
+
+    it('does not include PILs which were transferred out of and into the establishment either side of the billing period', () => {
+      return this.models.PIL.query().billable({ establishmentId: 102, start: '2018-04-06', end: '2019-04-05' })
+        .then(results => isNotBillable(results, 'manytransfers@example.com'));
+    });
+
+  });
+
+});


### PR DESCRIPTION
Allows querying for the billable PILs for a given year and given establishment.

Adds some transfers to the seeds to allow for testing of billing queries.