### PR TITLE
Add a fast prefilter to PIL transfer query

### DIFF
--- a/schema/pil.js
+++ b/schema/pil.js
@@ -57,7 +57,10 @@ class PILQueryBuilder extends BaseModel.QueryBuilder {
           // the first PIL transfer after the end of the billing period was out of the establishment
           .orWhere(builder => {
             builder
-              .where(
+              .whereExists(
+                PIL.relatedQuery('pilTransfers').where('createdAt', '>', end)
+              )
+              .andWhere(
                 establishmentId,
                 PIL.relatedQuery('pilTransfers')
                   .select('fromEstablishmentId')


### PR DESCRIPTION
Running the sort/limit query on PIL transfer is an expensive operation to do before getting an establishment to compare because it gets done many times inside quite a large loop.

Check that the PIL has _ever_ been transferred first before doing repeated sort operations on the table.

This reduces execution time on the query by ~80%