### PR TITLE
Fix place seeds

### DIFF
--- a/seeds/tables/places.js
+++ b/seeds/tables/places.js
@@ -8,16 +8,12 @@ module.exports = {
       .then(() => knex('roles').where('type', 'nacwo'))
       .then(nacwos => {
         return Promise.all(places.map(place => {
+          place.holding = place.holding || sampleSize(holdingCodes, 2);
+          place.suitability = place.suitability || sampleSize(suitabilityCodes, 2);
           return knex('places')
             .insert({
               nacwoId: place.nacwoId || sample(nacwos).id,
               ...mapValues(place, (val, key) => {
-                if (key === 'holding') {
-                  val = val || sampleSize(holdingCodes, 2);
-                }
-                if (key === 'suitability') {
-                  val = val || sampleSize(suitabilityCodes, 2);
-                }
                 if (key === 'holding' || key === 'suitability') {
                   return JSON.stringify(val);
                 }


### PR DESCRIPTION
The seed values for places that default holding and suitability codes can't be inside the `mapValues` because the values don't exist and so don't get mapped.

Instead set the default values at the level above.