### PR TITLE
Rename legacy conversion column for different purpose

### DIFF
--- a/migrations/20200225145750_rename_legacy_conversion_col.js
+++ b/migrations/20200225145750_rename_legacy_conversion_col.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('projects', table => {
+    table.renameColumn('is_legacy_conversion', 'is_legacy_stub');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('projects', table => {
+    table.renameColumn('is_legacy_stub', 'is_legacy_conversion');
+  });
+};

--- a/schema/project.js
+++ b/schema/project.js
@@ -29,7 +29,7 @@ class Project extends BaseModel {
         licenceHolderId: { type: ['string', 'null'] },
         deleted: { type: ['string', 'null'], format: 'date-time' },
         amendedDate: { type: ['string', 'null'], format: 'date-time' },
-        isLegacyConversion: { type: 'boolean' }
+        isLegacyStub: { type: 'boolean' }
       }
     };
   }


### PR DESCRIPTION
Flag as originally conceived was to say whether the project was ever a conversion of a legacy licence.

It's now used to determine if at the current time the project is a stub licence rather than a fully migrated legacy licence. Initially the flag will be set to true, then once all the details are filled in and submitted, the flag will be set to false.