### PR TITLE
Use explicit status check to see if a PIL is active for billing purposes

### DIFF
--- a/schema/pil.js
+++ b/schema/pil.js
@@ -26,7 +26,7 @@ class PILQueryBuilder extends BaseModel.QueryBuilder {
           .whereNotNull('issueDate')
           .where(builder => {
             builder
-              .whereNull('revocationDate')
+              .where('status', 'active')
               .orWhere('revocationDate', '>', start);
           });
       })

--- a/test/functional/pil.js
+++ b/test/functional/pil.js
@@ -161,6 +161,18 @@ describe('PIL model', () => {
                       }
                     ]
                   }
+                },
+                {
+                  firstName: 'Reactivated',
+                  lastName: 'Pil',
+                  email: 'reactivated@example.com',
+                  pil: {
+                    establishmentId: 101,
+                    procedures: ['A'],
+                    status: 'active',
+                    issueDate: '2018-01-01T12:00:00Z',
+                    revocationDate: '2017-01-01T12:00:00Z'
+                  }
                 }
               ]
             }
@@ -199,6 +211,11 @@ describe('PIL model', () => {
     it('does not include PILs which were granted after the billing period', () => {
       return this.models.PIL.query().billable({ establishmentId: 102, start: '2016-04-06', end: '2017-04-05' })
         .then(results => isNotIncluded(results, 'activepil@example.com'));
+    });
+
+    it('includes PILs which were re-granted after being revoked', () => {
+      return this.models.PIL.query().billable({ establishmentId: 101, start: '2018-04-06', end: '2019-04-05' })
+        .then(results => isIncluded(results, 'reactivated@example.com'));
     });
 
     it('does not include PILs which were transfered into the establishment after the billing period', () => {


### PR DESCRIPTION
Using the absence of a revocation date to determine if a PIL is active ignores any that were revoked and then re-granted later. Instead use an explicit check for a status of `active` to infer whether a PIL is active.