### PR TITLE
Use non-ambiguous status column in project status query

### DIFF
--- a/schema/project.js
+++ b/schema/project.js
@@ -5,7 +5,7 @@ const { uuid } = require('../lib/regex-validation');
 
 const statusQuery = status => query => Array.isArray(status)
   ? query.whereIn('projects.status', status)
-  : query.where({ status });
+  : query.where('projects.status', status);
 
 class Project extends BaseModel {
   static get tableName() {

--- a/test/functional/project.js
+++ b/test/functional/project.js
@@ -38,7 +38,12 @@ describe('Project model', () => {
             licenceHolder: {
               id: '781d8d17-9c00-4f3d-8734-c1a469426546'
             },
-            status: 'inactive'
+            status: 'inactive',
+            version: [
+              {
+                status: 'draft'
+              }
+            ]
           },
           {
             title: 'Some expired research',
@@ -53,7 +58,12 @@ describe('Project model', () => {
             licenceHolder: {
               id: '781d8d17-9c00-4f3d-8734-c1a469426546'
             },
-            status: 'inactive'
+            status: 'inactive',
+            version: [
+              {
+                status: 'submitted'
+              }
+            ]
           },
           {
             title: 'Some more expired research',
@@ -205,6 +215,22 @@ describe('Project model', () => {
           }))
           .then(project => {
             assert.deepEqual(project, null);
+          });
+      });
+    });
+
+    describe('getAll', () => {
+      it('returns only submitted drafts to ASRU users', () => {
+        const params = {
+          establishmentId: 8201,
+          status: 'inactive',
+          isAsru: true
+        };
+        return Promise.resolve()
+          .then(() => this.models.Project.scopeToParams(params).getAll())
+          .then(({ projects }) => {
+            assert.equal(projects.results.length, 1);
+            assert.equal(projects.results[0].title, 'Some more research', 'Only the project with a submitted version should be returned');
           });
       });
     });


### PR DESCRIPTION
If used in a query with a `project_versions` join then this throws an "ambiguous column" error because there are two tables used in the query with the same name.

Specifically, when viewing draft projects as an ASRU user this fails.