### PR TITLE
Fix scoping of soft deleted query builder

### DIFF
--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -50,7 +50,9 @@ class BaseModel extends Model {
 
   static query(...args) {
     return super.query(...args)
-      .where(`${this.tableName}.deleted`, null);
+      .onBuild(builder => {
+        return builder.whereNull(`${builder.tableRefFor(builder.modelClass())}.deleted`);
+      });
   }
 
   static queryWithDeleted(...args) {


### PR DESCRIPTION
Apply the additional `whereNotNull` clause at query build time rather than creation time so that subsequent aliases of the table name can be respected, and therefore relations can have different names to the underlying tables.