### PR TITLE
Remove keepalive from docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . /app
 
 RUN rm /app/.npmrc
 
-CMD npm run migrate && ./keepalive.sh
+CMD npm run migrate

--- a/keepalive.sh
+++ b/keepalive.sh
@@ -1,6 +1,0 @@
-touch /app/ready
-touch /app/alive
-
-while true;
-  do sleep 30;
-done;


### PR DESCRIPTION
There's no reason not to allow the container to exit with a zero status code.

Keeping it running uses resources that we don't need to.