### PR TITLE
Bugfix - Set context for deleted subqueries

### DIFF
--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -51,12 +51,14 @@ class BaseModel extends Model {
   static query(...args) {
     return super.query(...args)
       .onBuild(builder => {
-        return builder.whereNull(`${builder.tableRefFor(builder.modelClass())}.deleted`);
+        if (!builder.context().withDeleted) {
+          return builder.whereNull(`${builder.tableRefFor(builder.modelClass())}.deleted`);
+        }
       });
   }
 
   static queryWithDeleted(...args) {
-    return super.query(...args);
+    return this.query(...args).context({ withDeleted: true });
   }
 
   static queryDeleted(...args) {


### PR DESCRIPTION
* queryWithDeleted was not eager loading deleted models due to them being filtered out in master query call. set context to avoid this