### PR TITLE
Remove keepalive script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . /app
 
 RUN rm /app/.npmrc
 
-CMD npm run migrate && ./keepalive.sh
+CMD npm run migrate

--- a/keepalive.sh
+++ b/keepalive.sh
@@ -1,6 +1,0 @@
-touch /app/ready
-touch /app/alive
-
-while true;
-  do sleep 30;
-done;


### PR DESCRIPTION
Migrations and seeds are run as Jobs now, so there's no need to keep the pod running once migrations have finished.