### PR TITLE
Default seed project version title to project title

### DIFF
--- a/seeds/tables/project-versions.js
+++ b/seeds/tables/project-versions.js
@@ -68,7 +68,20 @@ module.exports = {
       .reverse()
       .reduce((p, projectVersion) => {
         projectVersion.data = merge({}, defaults, projectVersion.data);
-        return p.then(() => knex('projectVersions').insert(projectVersion));
+        return p
+          .then(() => {
+            if (!projectVersion.title) {
+              return knex('projects')
+                .select('title')
+                .where('id', projectVersion.projectId)
+                .first()
+                .then(result => {
+                  return { ...projectVersion, data: { ...projectVersion.data, ...result } };
+                });
+            }
+            return projectVersion;
+          })
+          .then(version => knex('projectVersions').insert(version));
       }, Promise.resolve());
   },
   delete: knex => knex('projectVersions').del()


### PR DESCRIPTION
If a project version has no title set in data then default it to the parent project's title. Because life is too short to have to replicate the data every time.