### PR TITLE
Set all existing v1 PPLs to not be training licences

### DIFF
--- a/migrations/20200710110948_training_and_education_ppls_false.js
+++ b/migrations/20200710110948_training_and_education_ppls_false.js
@@ -1,0 +1,39 @@
+
+exports.up = function(knex) {
+  return Promise.resolve()
+    .then(() => {
+      return knex('project_versions')
+        .select('project_versions.id')
+        .join('projects', 'project_versions.project_id', 'projects.id')
+        .where({ 'schema_version':  1 })
+        .whereRaw('data->>\'training-licence\' IS NULL');
+    })
+    .then(versions => {
+      console.log(`found ${versions.length} versions`)
+      return versions.reduce((promise, version, index) => {
+        return promise
+          .then(() => {
+            console.log(`patching version: ${version.id}, ${index + 1} of ${versions.length}`);
+            return knex('project_versions')
+              .select('project_versions.id', 'data')
+              .where({ 'project_versions.id': version.id })
+              .first()
+              .then(version => {
+                const data = { ['training-licence']: false, ...version.data };
+                return knex('project_versions')
+                  .where({ id: version.id })
+                  .update({ data });
+              });
+          })
+          .catch(e => {
+            console.error(`Failed to update project ${version.id}`);
+            console.error(e.stack);
+            throw e;
+          });
+      }, Promise.resolve());
+    });
+};
+
+exports.down = function(knex) {
+  return Promise.resolve();
+};

--- a/migrations/20200710110948_training_and_education_ppls_false.js
+++ b/migrations/20200710110948_training_and_education_ppls_false.js
@@ -1,3 +1,7 @@
+exports.transform = data => {
+  const isTrainingLicence = data['training-licence'] || (data['permissible-purpose'] || []).includes('higher-education');
+  return { ['training-licence']: isTrainingLicence, ...data };
+};
 
 exports.up = function(knex) {
   return Promise.resolve()
@@ -19,7 +23,7 @@ exports.up = function(knex) {
               .where({ 'project_versions.id': version.id })
               .first()
               .then(version => {
-                const data = { ['training-licence']: false, ...version.data };
+                const data = transform(version.data);
                 return knex('project_versions')
                   .where({ id: version.id })
                   .update({ data });

--- a/seeds/data/project-versions.json
+++ b/seeds/data/project-versions.json
@@ -565,5 +565,13 @@
         }
       ]
     }
+  },
+  {
+    "projectId": "23e96d12-74d5-4ccb-ba3f-ec16829d4b6d",
+    "status": "granted",
+    "data": {
+      "title": "Training licence",
+      "training-licence": true
+    }
   }
 ]

--- a/seeds/data/projects.json
+++ b/seeds/data/projects.json
@@ -565,5 +565,13 @@
     "status": "active",
     "schemaVersion": 1,
     "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd"
+  },
+  {
+    "id": "23e96d12-74d5-4ccb-ba3f-ec16829d4b6d",
+    "establishmentId": 8201,
+    "title": "Training licence",
+    "status": "active",
+    "schemaVersion": 1,
+    "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd"
   }
 ]

--- a/test/migrations/20200710110948_training_and_education_ppls_false.js
+++ b/test/migrations/20200710110948_training_and_education_ppls_false.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const { transform } = require('../../migrations/20200710110948_training_and_education_ppls_false');
+
+describe('Training PPLs migration', () => {
+
+  describe('transform', () => {
+
+    it('sets `training-licence` to false if not included in permissible purpose', () => {
+      const input = {
+        'permissible-purpose': ['basic-research']
+      };
+      assert.equal(transform(input)['training-licence'], false);
+    });
+
+    it('sets `training-licence` to false if no permissible purpose is set', () => {
+      const input = {};
+      assert.equal(transform(input)['training-licence'], false);
+    });
+
+    it('sets `training-licence` to true if permissible purpose includes `higher-education`', () => {
+      const input = {
+        'permissible-purpose': ['basic-research', 'higher-education']
+      };
+      assert.equal(transform(input)['training-licence'], true);
+    });
+
+    it('preserves `permissible-purpose` property', () => {
+      const input = {
+        'permissible-purpose': ['basic-research', 'higher-education']
+      };
+      assert.deepEqual(transform(input)['permissible-purpose'], ['basic-research', 'higher-education']);
+    });
+
+    it('preserves other properties', () => {
+      const input = {
+        title: 'Test project title',
+        'permissible-purpose': ['basic-research', 'higher-education']
+      };
+      assert.equal(transform(input).title, 'Test project title');
+    });
+
+  });
+
+});


### PR DESCRIPTION
If the property is left undefined then the permissible purpose doesn't appear when in review mode (because it's nested under the training licence Q now), which will potentially break all existing applications and amendments.

Default the new parent question to false so that when the schema changes the sub-question will remain visible.