### PR TITLE
Add migration to add RA to training and education PPLs

### DIFF
--- a/migrations/20200722154144_training_ppls_ra.js
+++ b/migrations/20200722154144_training_ppls_ra.js
@@ -1,0 +1,15 @@
+
+exports.up = function(knex) {
+  return knex('project_versions')
+    .where({
+      ra_compulsory: false
+    })
+    .whereRaw(`"data" @> '{ "training-licence": true }'`)
+    .update({
+      ra_compulsory: true
+    });
+};
+
+exports.down = function(knex) {
+  return Promise.resolve();
+};

--- a/migrations/20200722155323_add_ra_date_to_projects_again.js
+++ b/migrations/20200722155323_add_ra_date_to_projects_again.js
@@ -1,0 +1,65 @@
+const moment = require('moment');
+const { addedByAsru } = require('../lib/retrospective-assessment');
+
+function getRaDate(version, project) {
+  if (!version || !project || !version.data) {
+    return null;
+  }
+  if (!version.ra_compulsory && !addedByAsru(version.data)) {
+    return null;
+  }
+
+  const date = project.status === 'revoked'
+    ? project.revocation_date
+    : project.expiry_date;
+
+  return moment(date).add(6, 'months').toISOString();
+}
+
+exports.getRaDate = getRaDate;
+
+exports.up = function(knex) {
+  return Promise.resolve()
+    .then(() => {
+      return knex('projects')
+        .select('id', 'expiry_date', 'revocation_date', 'status')
+        .whereIn('status', ['active', 'revoked', 'expired'])
+        .where({ schema_version: 1 })
+        .whereNull('ra_date');
+    })
+    .then(projects => {
+      console.log(`found ${projects.length} projects`);
+      return projects.reduce((promise, project, index) => {
+        return promise
+          .then(() => {
+            console.log(`patching project: ${project.id}, ${index + 1} of ${projects.length}`);
+            return knex('project_versions')
+              .select('id', 'data', 'ra_compulsory')
+              .where({ 'project_id': project.id, status: 'granted' })
+              .orderBy('created_at', 'desc')
+              .first()
+              .then(version => {
+                const ra_date = getRaDate(version, project);
+                if (!ra_date) {
+                  return Promise.resolve();
+                }
+                return knex('projects')
+                  .where({ id: project.id })
+                  .update({ ra_date });
+              })
+              .then(() => {
+                console.log(`finshed patching project: ${project.id}, ${index + 1} of ${projects.length}`);
+              });
+          })
+          .catch(e => {
+            console.error(`Failed to update project: ${project.id}`);
+            console.error(e.stack);
+            throw e;
+          });
+      }, Promise.resolve());
+    });
+};
+
+exports.down = function(knex) {
+  return Promise.resolve();
+};

--- a/seeds/data/projects.json
+++ b/seeds/data/projects.json
@@ -491,6 +491,9 @@
     "title": "Training licence",
     "status": "active",
     "schemaVersion": 1,
-    "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd"
+    "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd",
+    "issueDate": "2020-02-05",
+    "expiryDate": "2025-02-05",
+    "licenceNumber": "XY-12345678"
   }
 ]


### PR DESCRIPTION
First migration sets the compulsory flag on all versions which have `training-licence` set to true.

Second migration re-calculates the RA date on the top-level project for any licences which may have been affected by the first migration - and is an almost complete clone of the [20200710 migration](https://github.com/UKHomeOffice/asl-schema/blob/master/migrations/20200710141816_add_ra_date_to_projects.js) to add RA dates to projects before, except it is limited to only those which are not _already_ set as having RA dates since this change will not unset any RA flags.