### PR TITLE
Migration - flatten modules in certificates

### DIFF
--- a/migrations/20200803123703_flatten_certificate_modules.js
+++ b/migrations/20200803123703_flatten_certificate_modules.js
@@ -1,0 +1,41 @@
+const { uniq } = require('lodash');
+
+function transform(certificate) {
+  if (!certificate.modules || !certificate.modules.length) {
+    return;
+  }
+  const species = certificate.species || [];
+  const speciesFromModules = uniq((certificate.modules || []).reduce((arr, mod) => [ ...arr, ...(mod.species || []) ], []));
+  return {
+    species: JSON.stringify(uniq([...species, ...speciesFromModules])),
+    modules: JSON.stringify(certificate.modules.map(module => module.module || module))
+  };
+}
+
+exports.transform = transform;
+
+exports.up = function(knex) {
+  return knex('certificates')
+    .select('id', 'species', 'modules')
+    .then(certs => {
+      return certs.reduce((promise, certificate) => {
+        return promise.then(() => {
+          const patch = transform(certificate);
+          if (!patch) {
+            return Promise.resolve();
+          }
+          return knex('certificates')
+            .where('id', certificate.id)
+            .update(patch);
+        })
+        .catch(err => {
+          console.error(err);
+          console.log(`Error processing ${cert.id}`);
+        })
+      }, Promise.resolve());
+    });
+};
+
+exports.down = function(knex) {
+  return Promise.resolve();
+};

--- a/migrations/20200803123703_flatten_certificate_modules.js
+++ b/migrations/20200803123703_flatten_certificate_modules.js
@@ -28,10 +28,10 @@ exports.up = function(knex) {
             .where('id', certificate.id)
             .update(patch);
         })
-        .catch(err => {
-          console.error(err);
-          console.log(`Error processing ${cert.id}`);
-        })
+          .catch(err => {
+            console.error(err);
+            console.log(`Error processing ${certificate.id}`);
+          });
       }, Promise.resolve());
     });
 };

--- a/migrations/20200803150819_migrate_exemptions_to_certs.js
+++ b/migrations/20200803150819_migrate_exemptions_to_certs.js
@@ -61,5 +61,5 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return Promise.resolve();
+  return knex('certificates').where('is_exemption', true).delete();
 };

--- a/migrations/20200803150819_migrate_exemptions_to_certs.js
+++ b/migrations/20200803150819_migrate_exemptions_to_certs.js
@@ -1,0 +1,65 @@
+const { uniq } = require('lodash');
+
+function uniqConcat(a, b) {
+  return uniq([
+    ...(a || []),
+    ...(b || [])
+  ]);
+}
+
+function transform(exemptions) {
+  return exemptions.reduce((cert, exemption) => {
+    const exemption_reason = cert.exemption_reason || '';
+    return {
+      species: uniqConcat(cert.species, exemption.species),
+      modules: uniqConcat(cert.modules, [exemption.module]),
+      exemption_reason: [
+        exemption_reason,
+        ...(exemption_reason.length ? ['\n'] : []),
+        exemption.description
+      ].join(''),
+      profile_id: exemption.profile_id,
+      created_at: exemption.created_at,
+      updated_at: exemption.updated_at
+    };
+  }, {});
+}
+
+exports.transform = transform;
+
+exports.up = function(knex) {
+  return Promise.resolve()
+    .then(() => {
+      return knex('exemptions')
+        .distinct('profile_id');
+    })
+    .then(profiles => {
+      console.log(`found ${profiles.length} profiles with exemptions`);
+      return profiles.reduce((promise, profile) => {
+        return promise.then(() => {
+          return knex('exemptions')
+            .where('profile_id', profile.profile_id)
+            .whereNull('deleted')
+            .orderBy('created_at', 'asc')
+            .then(exemptions => {
+              console.log(`found ${exemptions.length} exemptions for profile ${profile.profile_id}`);
+              const certificate = transform(exemptions);
+              return knex('certificates').insert({
+                ...certificate,
+                is_exemption: true,
+                modules: JSON.stringify(certificate.modules),
+                species: JSON.stringify(certificate.species)
+              });
+            })
+            .catch(err => {
+              console.log(`Failed combining exemptions for profile ${profile.profile_id}`);
+              console.error(err);
+            });
+        });
+      }, Promise.resolve());
+    });
+};
+
+exports.down = function(knex) {
+  return Promise.resolve();
+};

--- a/schema/certificate.js
+++ b/schema/certificate.js
@@ -17,16 +17,7 @@ class Certificate extends BaseModel {
         migratedId: { type: ['string', 'null'] },
         modules: {
           type: ['array', 'null'],
-          items: {
-            type: 'object',
-            properties: {
-              module: { type: 'string', enum: moduleCodes },
-              species: {
-                type: ['array', 'null'],
-                items: { type: 'string' }
-              }
-            }
-          }
+          items: { type: 'string', enum: moduleCodes }
         },
         species: {
           type: ['array', 'null'],

--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -82,6 +82,21 @@
     "email": "vice-chancellor@example.com",
     "telephone": "01840 345 678",
     "notes": "",
+    "certificates": [
+      {
+        "modules": [
+          "PILA (theory)",
+          "PILA (skills)"
+        ],
+        "species": [
+          "Mice",
+          "Rats"
+        ],
+        "passDate": "2015-06-04",
+        "accreditingBody": "Royal Society of Biology",
+        "certificateNumber": "12345"
+      }
+    ],
     "roles": [
       {
         "establishmentId": 8201,
@@ -221,6 +236,21 @@
       {
         "establishmentId": 8201,
         "role": "basic"
+      }
+    ],
+    "certificates": [
+      {
+        "modules": [
+          "PILA (theory)",
+          "PILA (skills)"
+        ],
+        "species": [
+          "Mice",
+          "Rats"
+        ],
+        "passDate": "2015-06-04",
+        "accreditingBody": "Royal Society of Biology",
+        "certificateNumber": "12345"
       }
     ]
   },
@@ -389,12 +419,8 @@
     "certificates": [
       {
         "modules": [
-          {
-            "module": "PILA (theory)"
-          },
-          {
-            "module": "PILA (skills)"
-          }
+          "PILA (theory)",
+          "PILA (skills)"
         ],
         "species": [
           "Mice",
@@ -403,12 +429,11 @@
         "passDate": "2015-06-04",
         "accreditingBody": "Royal Society of Biology",
         "certificateNumber": "12345"
-      }
-    ],
-    "exemptions": [
+      },
       {
-        "module": "PILB",
-        "description": "Years of experience",
+        "modules": ["PILB"],
+        "isExemption": true,
+        "exemptionReason": "Years of experience",
         "species": [
           "Mice",
           "Rats"

--- a/seeds/tables/project-versions.js
+++ b/seeds/tables/project-versions.js
@@ -59,7 +59,8 @@ const defaults = {
   'animals-containing-human-material': false,
   'containing-human-material-complete': true,
   'animals-taken-from-the-wild-complete': true,
-  'establishments-care-conditions-justification': null
+  'establishments-care-conditions-justification': null,
+  'training-complete': true
 };
 
 module.exports = {

--- a/test/migrations/20200803123703_flatten_certificate_modules.js
+++ b/test/migrations/20200803123703_flatten_certificate_modules.js
@@ -1,0 +1,212 @@
+const uuid = require('uuid/v4');
+const assert = require('assert');
+const db = require('./helpers/db');
+const { transform, up } = require('../../migrations/20200803123703_flatten_certificate_modules');
+
+describe('transform', () => {
+  it('returns undefined if called without modules', () => {
+    assert.equal(transform({ species: ['Cats'] }), undefined);
+  });
+
+  it('returns undefined if module is empty array', () => {
+    assert.equal(transform({ species: ['Cats'], modules: [] }), undefined);
+  });
+
+  it('flattens modules to a list of module strings, hoisting species to top level', () => {
+    const input = {
+      modules: [
+        {
+          module: 'PILA (theory)',
+          species: ['Cats']
+        }
+      ]
+    };
+    const expected = {
+      modules: JSON.stringify(['PILA (theory)']),
+      species: JSON.stringify(['Cats'])
+    };
+    assert.deepEqual(transform(input), expected);
+  });
+
+  it('combines species from all modules, and species if existing, ignoring dupes', () => {
+    const input = {
+      modules: [
+        {
+          module: 'PILA (theory)',
+          species: ['Mice', 'Rats']
+        },
+        {
+          module: 'PILA (skills)',
+          species: ['Cats']
+        }
+      ],
+      species: ['Mice', 'Cows']
+    };
+
+    const expected = {
+      modules: JSON.stringify(['PILA (theory)', 'PILA (skills)']),
+      species: JSON.stringify(['Mice', 'Cows', 'Rats', 'Cats'])
+    };
+    assert.deepEqual(transform(input), expected);
+  });
+});
+
+describe('up', () => {
+  const ids = {
+    holc: uuid(),
+    cert: {
+      noSpecies: uuid(),
+      repeatedSpecies: uuid(),
+      noModules: uuid(),
+      combinedFormat: uuid()
+    }
+  };
+
+  const profiles = [
+    {
+      id: ids.holc,
+      first_name: 'Bruce',
+      last_name: 'Banner',
+      email: 'holc@example.com'
+    }
+  ];
+
+  const certificates = [
+    {
+      id: ids.cert.noModules,
+      profile_id: ids.holc
+    },
+    {
+      id: ids.cert.noSpecies,
+      profile_id: ids.holc,
+      modules: JSON.stringify([
+        {
+          module: 'PILA (theory)',
+          species: ['Mice', 'Rats']
+        },
+        {
+          module: 'PILA (skills)',
+          species: ['Dogs']
+        }
+      ])
+    },
+    {
+      id: ids.cert.repeatedSpecies,
+      profile_id: ids.holc,
+      modules: JSON.stringify([
+        {
+          module: 'PILA (theory)',
+          species: ['Mice', 'Cats']
+        },
+        {
+          module: 'PILA (skills)',
+          species: ['Dogs']
+        },
+        {
+          module: 'K',
+          species: ['Horses']
+        }
+      ]),
+      species: JSON.stringify(['Mice', 'Rats'])
+    },
+    {
+      id: ids.cert.combinedFormat,
+      profile_id: ids.holc,
+      modules: JSON.stringify([
+        {
+          module: 'PILA (theory)',
+          species: ['Cats']
+        },
+        'PILA (skills)',
+        {
+          module: 'K',
+          species: ['BABU']
+        }
+      ]),
+      species: JSON.stringify(['JABU'])
+    }
+  ];
+
+  before(() => {
+    this.knex = db.init();
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => db.clean(this.knex))
+      .then(() => this.knex('profiles').insert(profiles))
+      .then(() => this.knex('certificates').insert(certificates));
+  });
+
+  afterEach(() => {
+    return db.clean(this.knex);
+  });
+
+  after(() => {
+    return this.knex.destroy();
+  });
+
+  it('doesnt make any changes in no modules detected', () => {
+    return Promise.resolve()
+      .then(() => this.knex('certificates').where('id', ids.cert.noModules).first())
+      .then(before => {
+        return Promise.resolve()
+          .then(() => up(this.knex))
+          .then(() => this.knex('certificates').where('id', ids.cert.noModules).first())
+          .then(after => {
+            assert.deepEqual(before, after);
+          });
+      });
+  });
+
+  it('adds species to top level from modules, and flattens modules', () => {
+    return Promise.resolve()
+      .then(() => this.knex('certificates').where('id', ids.cert.noSpecies).first())
+      .then(before => {
+        return Promise.resolve()
+          .then(() => up(this.knex))
+          .then(() => this.knex('certificates').where('id', ids.cert.noSpecies).first())
+          .then(after => {
+            const expected = {
+              modules: ['PILA (theory)', 'PILA (skills)'],
+              species: ['Mice', 'Rats', 'Dogs']
+            };
+            assert.deepEqual(after, { ...before, ...expected });
+          });
+      });
+  });
+
+  it('adds species to top level from modules, and flattens modules', () => {
+    return Promise.resolve()
+      .then(() => this.knex('certificates').where('id', ids.cert.repeatedSpecies).first())
+      .then(before => {
+        return Promise.resolve()
+          .then(() => up(this.knex))
+          .then(() => this.knex('certificates').where('id', ids.cert.repeatedSpecies).first())
+          .then(after => {
+            const expected = {
+              modules: ['PILA (theory)', 'PILA (skills)', 'K'],
+              species: ['Mice', 'Rats', 'Cats', 'Dogs', 'Horses']
+            };
+            assert.deepEqual(after, { ...before, ...expected });
+          });
+      });
+  });
+
+  it('handles combined module format', () => {
+    return Promise.resolve()
+      .then(() => this.knex('certificates').where('id', ids.cert.combinedFormat).first())
+      .then(before => {
+        return Promise.resolve()
+          .then(() => up(this.knex))
+          .then(() => this.knex('certificates').where('id', ids.cert.combinedFormat).first())
+          .then(after => {
+            const expected = {
+              modules: ['PILA (theory)', 'PILA (skills)', 'K'],
+              species: ['JABU', 'Cats', 'BABU']
+            };
+            assert.deepEqual(after, { ...before, ...expected });
+          });
+      });
+  });
+});

--- a/test/migrations/20200803150819_migrate_exemptions_to_certs.js
+++ b/test/migrations/20200803150819_migrate_exemptions_to_certs.js
@@ -1,0 +1,195 @@
+const uuid = require('uuid/v4');
+const moment = require('moment');
+const { isMatch } = require('lodash');
+const assert = require('assert');
+const db = require('./helpers/db');
+const { transform, up } = require('../../migrations/20200803150819_migrate_exemptions_to_certs');
+
+describe('transform', () => {
+  it('returns an empty object if called with an empty array', () => {
+    assert.deepEqual(transform([]), {});
+  });
+
+  it('combines exemption reasons, separating with new lines', () => {
+    const input = [
+      {
+        description: 'First reason'
+      },
+      {
+        description: 'Second reason'
+      }
+    ];
+    const expected = 'First reason\nSecond reason';
+    assert.deepEqual(transform(input).exemption_reason, expected);
+  });
+
+  it('combines modules', () => {
+    const input = [
+      {
+        module: 'PILA (theory)'
+      },
+      {
+        module: 'PILA (skills)'
+      }
+    ];
+    const expected = ['PILA (theory)', 'PILA (skills)'];
+    assert.deepEqual(transform(input).modules, expected);
+  });
+
+  it('combines species', () => {
+    const input = [
+      {
+        species: ['Mice', 'Rats']
+      },
+      {
+        species: ['JABU', 'BABU']
+      }
+    ];
+    const expected = ['Mice', 'Rats', 'JABU', 'BABU'];
+    assert.deepEqual(transform(input).species, expected);
+  });
+
+  it('combines multiple exemption models into a single certificate', () => {
+    const profile_id = uuid();
+    const created_at = moment().subtract(3, 'months').toISOString();
+    const updated_at = moment().subtract(1, 'months').toISOString();
+    const input = [
+      {
+        module: 'PILA (skills)',
+        species: ['Mice', 'Rats'],
+        description: 'First description',
+        profile_id,
+        created_at,
+        updated_at
+      },
+      {
+        module: 'PILA (theory)',
+        species: ['JABU', 'BABU'],
+        description: 'Second description',
+        profile_id,
+        created_at,
+        updated_at
+      }
+    ];
+    const expected = {
+      modules: ['PILA (skills)', 'PILA (theory)'],
+      species: ['Mice', 'Rats', 'JABU', 'BABU'],
+      exemption_reason: 'First description\nSecond description',
+      profile_id,
+      created_at,
+      updated_at
+    };
+    assert.deepEqual(transform(input), expected);
+  });
+});
+
+describe('up', () => {
+
+  const ids = {
+    profile: {
+      holc: uuid(),
+      archer: uuid()
+    }
+  };
+
+  const profiles = [
+    {
+      id: ids.profile.holc,
+      first_name: 'Bruce',
+      last_name: 'Banner',
+      email: 'holc@example.com'
+    },
+    {
+      id: ids.profile.archer,
+      first_name: 'Sterling',
+      last_name: 'Archer',
+      email: 'archer@example.com'
+    }
+  ];
+
+  const exemptions = [
+    {
+      profile_id: ids.profile.holc,
+      module: 'PILA (theory)',
+      species: JSON.stringify(['JABU', 'BABU']),
+      description: 'First description',
+      created_at: moment().subtract(4, 'months').toISOString(),
+      updated_at: moment().subtract(4, 'months').toISOString()
+    },
+    {
+      profile_id: ids.profile.holc,
+      module: 'PILA (skills)',
+      species: JSON.stringify(['Nemo', 'Dory']),
+      description: 'Second description',
+      created_at: moment().subtract(3, 'months').toISOString(),
+      updated_at: moment().subtract(3, 'months').toISOString()
+    },
+    {
+      profile_id: ids.profile.archer,
+      module: 'K',
+      species: JSON.stringify(['Mice']),
+      description: 'First description',
+      created_at: moment().subtract(3, 'months').toISOString(),
+      updated_at: moment().subtract(3, 'months').toISOString()
+    },
+    {
+      profile_id: ids.profile.archer,
+      module: 'PPL',
+      species: JSON.stringify(['Rats', 'Cats']),
+      description: 'Second description',
+      created_at: moment().subtract(2, 'months').toISOString(),
+      updated_at: moment().subtract(2, 'months').toISOString()
+    }
+  ];
+
+  before(() => {
+    this.knex = db.init();
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => db.clean(this.knex))
+      .then(() => this.knex('profiles').insert(profiles))
+      .then(() => this.knex('exemptions').insert(exemptions));
+  });
+
+  afterEach(() => {
+    return db.clean(this.knex);
+  });
+
+  after(() => {
+    return this.knex.destroy();
+  });
+
+  it('combines exemptions for holc', () => {
+    return Promise.resolve()
+      .then(() => up(this.knex))
+      .then(() => this.knex('certificates').where('profile_id', ids.profile.holc).first())
+      .then(certificate => {
+        const expected = {
+          profile_id: ids.profile.holc,
+          modules: ['PILA (theory)', 'PILA (skills)'],
+          species: ['JABU', 'BABU', 'Nemo', 'Dory'],
+          exemption_reason: 'First description\nSecond description',
+          is_exemption: true
+        };
+        assert.ok(isMatch(certificate, expected));
+      });
+  });
+
+  it('combines exemptions for other profile', () => {
+    return Promise.resolve()
+      .then(() => up(this.knex))
+      .then(() => this.knex('certificates').where('profile_id', ids.profile.archer).first())
+      .then(certificate => {
+        const expected = {
+          profile_id: ids.profile.archer,
+          modules: ['K', 'PPL'],
+          species: ['Mice', 'Rats', 'Cats'],
+          exemption_reason: 'First description\nSecond description',
+          is_exemption: true
+        };
+        assert.ok(isMatch(certificate, expected));
+      });
+  });
+});


### PR DESCRIPTION
This is currently normalised at API level - map species from modules on to top level prop, and flatten module objects to be a list of strings