### PR TITLE
Order profiles consistently

### DIFF
--- a/seeds/tables/projects.js
+++ b/seeds/tables/projects.js
@@ -12,6 +12,7 @@ module.exports = {
           .whereNotIn('firstName', nopes)
           .andWhere('asruUser', false)
           .andWhere('permissions.establishment_id', project.establishmentId)
+          .orderBy('email') // apply an ordering on a reliably populated field for consistency
           .then(profiles => {
             return knex('projects')
               .insert({


### PR DESCRIPTION
Because profiles were not sorted they were sensitive to database insertion order, and so did not produce reproducible seed data.