### PR TITLE
Make role assignment seeds repeatable

### DIFF
--- a/seeds/tables/places.js
+++ b/seeds/tables/places.js
@@ -24,7 +24,12 @@ module.exports = {
         }));
       })
       .then(() => {
-        return knex('roles').whereIn('type', ['nacwo', 'nvs', 'sqp']).where('establishment_id', 8201)
+        return knex('roles')
+          .select('roles.*')
+          .join('profiles', 'roles.profile_id', '=', 'profiles.id')
+          .whereIn('type', ['nacwo', 'nvs', 'sqp'])
+          .where('establishment_id', 8201)
+          .orderBy(['profiles.email', 'roles.type'])
           .then(roles => {
             const croydonPlaces = places.filter(place => place.establishmentId === 8201);
             const placesWithRolesDefined = croydonPlaces.filter(place => place.roles !== undefined);


### PR DESCRIPTION
The assignment of roles to places is currently dependent on database insertion order so it results in false-positives in the visual regression tests.

Add an explicit sort to the assignment so that it is reproducible across seed runs.