### PR TITLE
Handle case where user's pil is deleted

### DIFF
--- a/migrations/20200824182434_migrate_pil_licence_no_to_profile.js
+++ b/migrations/20200824182434_migrate_pil_licence_no_to_profile.js
@@ -20,6 +20,9 @@ exports.up = function(knex) {
               .orderBy('issue_date', 'desc')
               .first()
               .then(pil => {
+                if (!pil) {
+                  return;
+                }
                 return knex('profiles')
                   .where({ id: profile.id })
                   .update({ pil_licence_number: pil.licence_number });


### PR DESCRIPTION
If a user's only PIL record has been deleted then it will error when reading the licence number.

In this case continue without writing a licence number.