### PR TITLE
Assign a species-less training module to Bruce Banner

### DIFF
--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -95,6 +95,15 @@
         "passDate": "2015-06-04",
         "accreditingBody": "Royal Society of Biology",
         "certificateNumber": "12345"
+      },
+      {
+        "modules": [
+          "L"
+        ],
+        "species": null,
+        "passDate": "2015-06-05",
+        "accreditingBody": "Royal Society of Biology",
+        "certificateNumber": "1234567890"
       }
     ],
     "roles": [


### PR DESCRIPTION
There is a bug with editing a species-less module to have species. This facilitates testing the fix for that issue.