### PR TITLE
Migration - assign missing pilLicenceNumbers to profiles

### DIFF
--- a/migrations/20200921121510_assign_missing_pil_licence_numbers.js
+++ b/migrations/20200921121510_assign_missing_pil_licence_numbers.js
@@ -38,9 +38,6 @@ exports.up = function(knex) {
               });
           });
       }, Promise.resolve());
-    })
-    .catch(err => {
-      console.log(err);
     });
 };
 

--- a/migrations/20200921121510_assign_missing_pil_licence_numbers.js
+++ b/migrations/20200921121510_assign_missing_pil_licence_numbers.js
@@ -1,0 +1,49 @@
+const crypto = require('crypto');
+
+function generateLicenceNumber(knex) {
+  const buf = crypto.randomBytes(48).toString('hex');
+  const digits = buf.replace(/[a-z]/g, '').substring(0, 8);
+  const pilLicenceNumber = `I${digits}`;
+
+  return knex('profiles')
+    .where({ pil_licence_number: pilLicenceNumber })
+    .first()
+    .then(existing => {
+      if (existing) {
+        return generateLicenceNumber(knex);
+      }
+      return pilLicenceNumber;
+    });
+}
+
+exports.up = function(knex) {
+  return Promise.resolve()
+    .then(() => knex('profiles').whereNull('pil_licence_number').whereExists(
+      knex.select('*').from('pils').whereRaw('profiles.id = pils.profile_id').whereNotIn('status', ['inactive', 'pending'])
+    ))
+    .then(profiles => {
+      console.log(`patching ${profiles.length} profiles`);
+      return profiles.reduce((promise, profile) => {
+        return promise
+          .then(() => generateLicenceNumber(knex))
+          .then(licenceNumber => {
+            console.log(`Assigning pilLicenceNumber ${licenceNumber} to profile ${profile.id}`);
+            return Promise.resolve()
+              .then(() => knex('profiles').where('id', profile.id).first().update('pil_licence_number', licenceNumber))
+              .then(() => {
+                console.log(`Successfully patched ${profile.id}`);
+              })
+              .catch(() => {
+                console.error(`Error patching ${profile.id} with licence number ${licenceNumber}`);
+              });
+          });
+      }, Promise.resolve());
+    })
+    .catch(err => {
+      console.log(err);
+    });
+};
+
+exports.down = function(knex) {
+  return Promise.resolve();
+};

--- a/migrations/20200921121510_assign_missing_pil_licence_numbers.js
+++ b/migrations/20200921121510_assign_missing_pil_licence_numbers.js
@@ -28,14 +28,10 @@ exports.up = function(knex) {
           .then(() => generateLicenceNumber(knex))
           .then(licenceNumber => {
             console.log(`Assigning pilLicenceNumber ${licenceNumber} to profile ${profile.id}`);
-            return Promise.resolve()
-              .then(() => knex('profiles').where('id', profile.id).first().update('pil_licence_number', licenceNumber))
-              .then(() => {
-                console.log(`Successfully patched ${profile.id}`);
-              })
-              .catch(() => {
-                console.error(`Error patching ${profile.id} with licence number ${licenceNumber}`);
-              });
+            return knex('profiles').where('id', profile.id).first().update('pil_licence_number', licenceNumber);
+          })
+          .then(() => {
+            console.log(`Successfully patched ${profile.id}`);
           });
       }, Promise.resolve());
     });

--- a/test/functional/helpers/db.js
+++ b/test/functional/helpers/db.js
@@ -3,6 +3,8 @@ const settings = require('../../../knexfile').test;
 
 const tables = [
   'Changelog',
+  'TrainingPil',
+  'TrainingCourse',
   'AsruEstablishment',
   'ProjectProfile',
   'ProjectVersion',

--- a/test/migrations/20200921121510_assign_missing_pil_licence_numbers.js
+++ b/test/migrations/20200921121510_assign_missing_pil_licence_numbers.js
@@ -1,0 +1,129 @@
+const assert = require('assert');
+const uuid = require('uuid/v4');
+const moment = require('moment');
+const { up } = require('../../migrations/20200921121510_assign_missing_pil_licence_numbers');
+const db = require('./helpers/db');
+
+describe('generateLicenceNumber', () => {
+  const ids = {
+    hasLicenceNumber: uuid(),
+    missingLicenceNumber: uuid(),
+    missingLicenceNumberNoPil: uuid(),
+    hasInactivePil: uuid()
+  };
+
+  const establishment = {
+    id: 100,
+    name: 'An establishment',
+    email: 'an@establishment.com',
+    country: 'england',
+    address: '123 Somwhere street'
+  };
+
+  const profiles = [
+    {
+      id: ids.hasLicenceNumber,
+      first_name: 'Has',
+      last_name: 'LicenceNumber',
+      email: 'aaa@bbb.com',
+      pil_licence_number: 'EXISTING'
+    },
+    {
+      id: ids.missingLicenceNumber,
+      first_name: 'Missing',
+      last_name: 'LicenceNumber',
+      email: 'bbb@aaa.com'
+    },
+    {
+      id: ids.missingLicenceNumberNoPil,
+      first_name: 'Missing',
+      last_name: 'LicenceNumberNoPil',
+      email: 'bbb@ccc.com'
+    },
+    {
+      id: ids.hasInactivePil,
+      first_name: 'Has',
+      last_name: 'InactivePil',
+      email: 'ccc@ddd.com'
+    }
+  ];
+
+  const pils = [
+    {
+      status: 'active',
+      establishment_id: 100,
+      profile_id: ids.hasLicenceNumber,
+      issue_date: moment().toISOString(),
+      deleted: moment().toISOString()
+    },
+    {
+      status: 'active',
+      establishment_id: 100,
+      profile_id: ids.missingLicenceNumber,
+      issue_date: moment().toISOString()
+    },
+    {
+      status: 'inactive',
+      establishment_id: 100,
+      profile_id: ids.hasInactivePil,
+      issue_date: moment().toISOString()
+    }
+  ];
+
+  before(() => {
+    this.knex = db.init();
+  });
+
+  beforeEach(() => {
+    return Promise.resolve()
+      .then(() => db.clean(this.knex))
+      .then(() => this.knex('establishments').insert(establishment))
+      .then(() => this.knex('profiles').insert(profiles))
+      .then(() => this.knex('pils').insert(pils));
+  });
+
+  afterEach(() => {
+    return db.clean(this.knex);
+  });
+
+  after(() => {
+    return this.knex.destroy();
+  });
+
+  it('skips profiles that already have a pilLicenceNumber', () => {
+    return Promise.resolve()
+      .then(() => up(this.knex))
+      .then(() => this.knex('profiles').where('id', ids.hasLicenceNumber).first())
+      .then(profile => {
+        assert.equal(profile.pil_licence_number, 'EXISTING');
+      });
+  });
+
+  it('assigns a new pilLicenceNumber if missing, and has active pil', () => {
+    return Promise.resolve()
+      .then(() => up(this.knex))
+      .then(() => this.knex('profiles').where('id', ids.missingLicenceNumber).first())
+      .then(profile => {
+        assert.ok(profile.pil_licence_number);
+        assert.equal(profile.pil_licence_number.charAt(0), 'I');
+      });
+  });
+
+  it('doesn\'t assign licence number to profile with no pil', () => {
+    return Promise.resolve()
+      .then(() => up(this.knex))
+      .then(() => this.knex('profiles').where('id', ids.missingLicenceNumberNoPil).first())
+      .then(profile => {
+        assert.equal(profile.pil_licence_number, null);
+      });
+  });
+
+  it('doesn\'t assign licence number to profile with inactive', () => {
+    return Promise.resolve()
+      .then(() => up(this.knex))
+      .then(() => this.knex('profiles').where('id', ids.hasInactivePil).first())
+      .then(profile => {
+        assert.equal(profile.pil_licence_number, null);
+      });
+  });
+});

--- a/test/migrations/helpers/db.js
+++ b/test/migrations/helpers/db.js
@@ -3,6 +3,8 @@ const settings = require('../../../knexfile').test;
 
 const tables = [
   'changelog',
+  'training_pils',
+  'training_courses',
   'place_roles',
   'project_versions',
   'projects',


### PR DESCRIPTION
* check for profiles with null pilLicenceNumber and a pil which is not inactive or pending, generate licence numbers for these