### PR TITLE
Move PIL fee waivers to be based on a Profile and not a PIL

### DIFF
--- a/migrations/20201006111459_pil-e-fee-waivers.js
+++ b/migrations/20201006111459_pil-e-fee-waivers.js
@@ -1,0 +1,47 @@
+
+exports.up = function(knex) {
+  return Promise.resolve()
+    .then(() => {
+      return knex.schema
+        .createTable('pil_fee_waivers', table => {
+          table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+
+          table.integer('year').notNull();
+          table.index('year');
+
+          table.uuid('profile_id').references('id').inTable('profiles').notNull();
+          table.index('profile_id');
+
+          table.integer('establishment_id').references('id').inTable('establishments').notNull();
+          table.index('establishment_id');
+
+          table.text('comment');
+          table.uuid('waived_by_id').references('id').inTable('profiles').notNull();
+
+          table.timestamps(false, true);
+          table.dateTime('deleted');
+        });
+    })
+    .then(() => {
+      return knex.table('fee_waivers')
+        .join('pils', 'fee_waivers.pil_id', 'pils.id')
+        .select(
+          'fee_waivers.id',
+          'fee_waivers.establishment_id',
+          'fee_waivers.year',
+          'fee_waivers.comment',
+          'fee_waivers.updated_at',
+          'fee_waivers.created_at',
+          'fee_waivers.deleted',
+          { waived_by_id: 'fee_waivers.profile_id' },
+          'pils.profile_id'
+        );
+    })
+    .then(waivers => {
+      return knex('pil_fee_waivers').insert(waivers);
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('pil_fee_waivers');
+};

--- a/schema/fee-waiver.js
+++ b/schema/fee-waiver.js
@@ -3,21 +3,21 @@ const { uuid } = require('../lib/regex-validation');
 
 class FeeWaiver extends BaseModel {
   static get tableName() {
-    return 'feeWaivers';
+    return 'pilFeeWaivers';
   }
 
   static get jsonSchema() {
     return {
       type: 'object',
-      required: ['pilId', 'establishmentId', 'year'],
+      required: ['profileId', 'establishmentId', 'year'],
       additionalProperties: false,
       properties: {
         id: { type: 'string', pattern: uuid.v4 },
-        pilId: { type: 'string', pattern: uuid.v4 },
+        profileId: { type: 'string', pattern: uuid.v4 },
         establishmentId: { type: 'integer' },
         year: { type: 'integer' },
         comment: { type: 'text' },
-        profileId: { type: 'string', pattern: uuid.v4 },
+        waivedById: { type: 'string', pattern: uuid.v4 },
         createdAt: { type: 'string', format: 'date-time' },
         updatedAt: { type: 'string', format: 'date-time' }
       }
@@ -26,19 +26,19 @@ class FeeWaiver extends BaseModel {
 
   static get relationMappings() {
     return {
-      pil: {
+      profile: {
         relation: this.BelongsToOneRelation,
-        modelClass: `${__dirname}/pil`,
+        modelClass: `${__dirname}/profile`,
         join: {
-          from: 'feeWaivers.pilId',
-          to: 'pils.id'
+          from: 'pilFeeWaivers.profileId',
+          to: 'profiles.id'
         }
       },
       establishment: {
         relation: this.BelongsToOneRelation,
         modelClass: `${__dirname}/establishment`,
         join: {
-          from: 'feeWaivers.establishmentId',
+          from: 'pilFeeWaivers.establishmentId',
           to: 'establishments.id'
         }
       },
@@ -46,7 +46,7 @@ class FeeWaiver extends BaseModel {
         relation: this.BelongsToOneRelation,
         modelClass: `${__dirname}/profile`,
         join: {
-          from: 'feeWaivers.profileId',
+          from: 'pilFeeWaivers.waivedById',
           to: 'profiles.id'
         }
       }

--- a/schema/pil.js
+++ b/schema/pil.js
@@ -64,35 +64,6 @@ class PILQueryBuilder extends BaseModel.QueryBuilder {
       });
   }
 
-  billable({ establishmentId, start, end }) {
-    const year = parseInt(start.substr(0, 4), 10);
-    this.context({ establishmentId, year });
-    return this
-      .select([
-        'pils.*',
-        'profile.pilLicenceNumber as licenceNumber',
-        PIL.relatedQuery('feeWaivers')
-          .where({ establishmentId, year })
-          .select(1)
-          .as('waived')
-      ])
-      .eager('[profile.establishments, pilTransfers, feeWaivers]')
-      .modifyEager('profile.establishments', builder => {
-        builder.where('id', establishmentId);
-      })
-      .modifyEager('pilTransfers', builder => {
-        builder
-          .where('fromEstablishmentId', establishmentId)
-          .orWhere('toEstablishmentId', establishmentId);
-      })
-      .modifyEager('feeWaivers', builder => {
-        builder
-          .where('establishmentId', establishmentId);
-      })
-      .leftJoinRelation('profile')
-      .whereBillable({ establishmentId, start, end });
-  }
-
 }
 
 class PIL extends BaseModel {

--- a/schema/pil.js
+++ b/schema/pil.js
@@ -5,17 +5,6 @@ const Profile = require('./profile');
 
 class PILQueryBuilder extends BaseModel.QueryBuilder {
 
-  whereNotWaived() {
-    const { establishmentId, year } = this.context();
-    if (!establishmentId || !year) {
-      throw new Error('whereNotWaived requires a establishmentId and start date to be set in query context');
-    }
-    return this
-      .whereNotExists(
-        PIL.relatedQuery('feeWaivers').where({ establishmentId, year })
-      );
-  }
-
   whereBillable({ establishmentId, start, end }) {
     const year = parseInt(start.substr(0, 4), 10);
     this.context({ establishmentId, start, end, year });
@@ -207,14 +196,6 @@ class PIL extends BaseModel {
         join: {
           from: 'pils.id',
           to: 'pilTransfers.pilId'
-        }
-      },
-      feeWaivers: {
-        relation: this.HasManyRelation,
-        modelClass: `${__dirname}/fee-waiver`,
-        join: {
-          from: 'pils.id',
-          to: 'feeWaivers.pilId'
         }
       },
       profile: {

--- a/seeds/tables/profiles.js
+++ b/seeds/tables/profiles.js
@@ -121,6 +121,7 @@ module.exports = {
   },
   delete: knex => knex('pil_transfers').del()
     .then(() => knex('fee_waivers').del())
+    .then(() => knex('pil_fee_waivers').del())
     .then(() => knex('pils').del())
     .then(() => knex('permissions').del())
     .then(() => knex('invitations').del())

--- a/test/functional/billing.js
+++ b/test/functional/billing.js
@@ -1,0 +1,226 @@
+const assert = require('assert');
+const uuid = require('uuid/v4');
+const db = require('./helpers/db');
+
+const ids = {
+  asru: uuid(),
+  piles: [uuid(), uuid(), uuid(), uuid()],
+  pils: [uuid()],
+  ppl: uuid()
+};
+
+describe('Billing queries model', () => {
+
+  before(() => {
+    return Promise.resolve()
+      .then(() => {
+        this.models = db.init();
+      })
+      .then(() => db.clean(this.models));
+  });
+
+  after(() => {
+    return db.clean(this.models)
+      .then(() => this.models.destroy());
+  });
+
+  describe('billable', () => {
+
+    before(() => {
+      return Promise.resolve()
+        .then(() => {
+          return this.models.Profile.query().insert([
+            {
+              id: ids.asru,
+              firstName: 'Asru',
+              lastName: 'Admin',
+              email: 'asruadmin@example.com'
+            },
+            {
+              id: ids.piles[0],
+              firstName: 'Jeff',
+              lastName: 'Winger',
+              email: 'jw@example.com'
+            },
+            {
+              id: ids.piles[1],
+              firstName: 'Abed',
+              lastName: 'Nadir',
+              email: 'an@example.com'
+            },
+            {
+              id: ids.piles[2],
+              firstName: 'Troy',
+              lastName: 'Barnes',
+              email: 'tb@example.com'
+            },
+            {
+              id: ids.piles[3],
+              firstName: 'Annie',
+              lastName: 'Edison',
+              email: 'ae@example.com'
+            },
+            {
+              id: ids.pils[0],
+              firstName: 'Robert',
+              lastName: 'Oppenheimer',
+              email: 'ro@example.com'
+            }
+          ]);
+        })
+        .then(() => {
+          return this.models.Establishment.query().insertGraph([
+            {
+              id: 100,
+              name: 'Training Establishment',
+              projects: [
+                {
+                  id: ids.ppl,
+                  title: 'Training Project',
+                  status: 'active'
+                }
+              ]
+            },
+            {
+              id: 101,
+              name: 'Research Establishment',
+              pils: [
+                {
+                  issueDate: '2020-04-01T12:00:00Z',
+                  status: 'active',
+                  procedures: ['A'],
+                  species: ['mice'],
+                  profileId: ids.piles[3]
+                },
+                {
+                  issueDate: '2020-04-01T12:00:00Z',
+                  status: 'active',
+                  procedures: ['A'],
+                  species: ['mice'],
+                  profileId: ids.pils[0]
+                }
+              ]
+            }
+          ]);
+        })
+        .then(() => {
+          return this.models.TrainingCourse.query().insertGraph([
+            {
+              establishmentId: 100,
+              title: 'Training Course',
+              projectId: ids.ppl,
+              startDate: '2020-04-01',
+              species: [],
+              trainingPils: [
+                {
+                  // expired naturally
+                  profileId: ids.piles[0],
+                  issueDate: '2020-04-01T12:00:00Z',
+                  expiryDate: '2020-07-01T12:00:00Z',
+                  revocationDate: null,
+                  status: 'expired'
+                },
+                {
+                  // revoked before start of period
+                  profileId: ids.piles[1],
+                  issueDate: '2020-04-01T12:00:00Z',
+                  expiryDate: '2020-07-01T12:00:00Z',
+                  revocationDate: '2020-04-04T12:00:00Z',
+                  status: 'revoked'
+                },
+                {
+                  // revoked after start of period
+                  profileId: ids.piles[2],
+                  issueDate: '2020-04-01T12:00:00Z',
+                  expiryDate: '2020-07-01T12:00:00Z',
+                  revocationDate: '2020-04-07T12:00:00Z',
+                  status: 'revoked'
+                },
+                {
+                  // waived
+                  profileId: ids.piles[3],
+                  issueDate: '2020-04-01T12:00:00Z',
+                  expiryDate: '2020-07-01T12:00:00Z',
+                  revocationDate: null,
+                  status: 'expired'
+                }
+              ]
+            }
+          ]);
+        })
+        .then(() => {
+          return this.models.FeeWaiver.query().insertGraph([
+            {
+              establishmentId: 100,
+              profileId: ids.piles[3],
+              year: 2020,
+              waivedById: ids.asru
+            }
+          ]);
+        });
+    });
+
+    it('includes training pils in billing data', () => {
+      return Promise.resolve()
+        .then(() => {
+          return this.models.Profile.query()
+            .whereHasBillablePIL({ establishmentId: 100, start: '2020-04-06', end: '2021-04-05' });
+        })
+        .then(result => {
+          assert.equal(result.length, 3);
+        });
+    });
+
+    it('excludes training pils revoked before start of year', () => {
+      return Promise.resolve()
+        .then(() => {
+          return this.models.Profile.query()
+            .whereHasBillablePIL({ establishmentId: 100, start: '2020-04-06', end: '2021-04-05' });
+        })
+        .then(result => {
+          assert.ok(!result.map(p => p.email).includes('an@example.com'), 'result should not include Abed Nadir');
+        });
+    });
+
+    it('excludes waived PILs if `whereNotWaived` is applied', () => {
+      return Promise.resolve()
+        .then(() => {
+          return this.models.Profile.query()
+            .whereHasBillablePIL({ establishmentId: 100, start: '2020-04-06', end: '2021-04-05' })
+            .whereNotWaived();
+        })
+        .then(result => {
+          assert.equal(result.length, 2);
+          assert.ok(!result.map(p => p.email).includes('ae@example.com'), 'result should not include Annie Edison');
+        });
+    });
+
+    it('does not exclude waived PILs for other years if `whereNotWaived` is applied', () => {
+      return Promise.resolve()
+        .then(() => {
+          return this.models.Profile.query()
+            .whereHasBillablePIL({ establishmentId: 100, start: '2019-04-06', end: '2020-04-05' })
+            .whereNotWaived();
+        })
+        .then(result => {
+          assert.equal(result.length, 4);
+          assert.ok(result.map(p => p.email).includes('ae@example.com'), 'result should include Annie Edison');
+        });
+    });
+
+    it('includes ordinary PILs where a PIL-E is waived elsewhere', () => {
+      return Promise.resolve()
+        .then(() => {
+          return this.models.Profile.query()
+            .whereHasBillablePIL({ establishmentId: 101, start: '2020-04-06', end: '2021-04-05' })
+            .whereNotWaived();
+        })
+        .then(result => {
+          assert.equal(result.length, 2);
+          assert.ok(result.map(p => p.email).includes('ae@example.com'), 'result should include Annie Edison');
+        });
+    });
+
+  });
+
+});


### PR DESCRIPTION
This allows profiles with only training PILs or with a mixture of both types of PIL to have their fees waived.

It:
* adds a migration which creates a new table for fee waivers, and copies the old data across but with a new `profileId` field which points to the PIL holder, and with no reference to a PIL record.
* updates the FeeWaiver model to use the new table for storing fee waivers.
* adds a `whereHasBillablePIL` and `whereNotWaived` method to the Profile model for querying PIL billing data.