### PR TITLE
Add indexes to FKs commonly used in joins

### DIFF
--- a/migrations/20201008150145_add_indexes_to_pil_table.js
+++ b/migrations/20201008150145_add_indexes_to_pil_table.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('pils', table => {
+    table.index('establishment_id');
+    table.index('profile_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('pils', table => {
+    table.dropIndex('establishment_id');
+    table.dropIndex('profile_id');
+  });
+};

--- a/migrations/20201008150342_add_indexes_to_project_versions.js
+++ b/migrations/20201008150342_add_indexes_to_project_versions.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('project_versions', table => {
+    table.index('project_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('project_versions', table => {
+    table.dropIndex('project_id');
+  });
+};

--- a/migrations/20201008150553_add_indexes_to_projects.js
+++ b/migrations/20201008150553_add_indexes_to_projects.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('projects', table => {
+    table.index('licence_holder_id');
+    table.index('establishment_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('projects', table => {
+    table.dropIndex('licence_holder_id');
+    table.dropIndex('establishment_id');
+  });
+};

--- a/migrations/20201008151059_add_indexes_to_places.js
+++ b/migrations/20201008151059_add_indexes_to_places.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('places', table => {
+    table.index('establishment_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('places', table => {
+    table.dropIndex('establishment_id');
+  });
+};

--- a/migrations/20201008153949_add_indexes_to_roles.js
+++ b/migrations/20201008153949_add_indexes_to_roles.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('roles', table => {
+    table.index('profile_id');
+    table.index('establishment_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('roles', table => {
+    table.index('profile_id');
+    table.index('establishment_id');
+  });
+};

--- a/migrations/20201008154357_add_indexes_to_permissions.js
+++ b/migrations/20201008154357_add_indexes_to_permissions.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('permissions', table => {
+    table.index('establishment_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('permissions', table => {
+    table.index('establishment_id');
+  });
+};


### PR DESCRIPTION
We were missing indexes on some FK relations that get used in JOINs. There are more than I've added here but I've picked out the ones that have larger tables.

If you want to see what FKs are still missing indexes, this query will give you a list:
```
SELECT c.conrelid::regclass AS "table",
       /* list of key column names in order */
       string_agg(a.attname, ',' ORDER BY x.n) AS columns,
       pg_catalog.pg_size_pretty(
          pg_catalog.pg_relation_size(c.conrelid)
       ) AS size,
       c.conname AS constraint,
       c.confrelid::regclass AS referenced_table
FROM pg_catalog.pg_constraint c
   /* enumerated key column numbers per foreign key */
   CROSS JOIN LATERAL
      unnest(c.conkey) WITH ORDINALITY AS x(attnum, n)
   /* name for each key column */
   JOIN pg_catalog.pg_attribute a
      ON a.attnum = x.attnum
         AND a.attrelid = c.conrelid
WHERE NOT EXISTS
        /* is there a matching index for the constraint? */
        (SELECT 1 FROM pg_catalog.pg_index i
         WHERE i.indrelid = c.conrelid
           /* the first index columns must be the same as the
              key columns, but order doesn't matter */
           AND (i.indkey::smallint[])[0:cardinality(c.conkey)-1]
               @> c.conkey)
  AND c.contype = 'f'
GROUP BY c.conrelid, c.conname, c.confrelid
ORDER BY pg_catalog.pg_relation_size(c.conrelid) DESC;
```