### PR TITLE
Add document cache model

### DIFF
--- a/migrations/20201020164654_cache_table.js
+++ b/migrations/20201020164654_cache_table.js
@@ -1,0 +1,13 @@
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('document_cache', table => {
+      table.string('id').primary();
+      table.jsonb('document');
+      table.timestamps(false, true);
+    });
+};
+
+exports.down = function(knex) {
+  knex.schema.dropTable('document_cache');
+};

--- a/schema/document-cache.js
+++ b/schema/document-cache.js
@@ -1,0 +1,78 @@
+const moment = require('moment');
+const { Model } = require('objection');
+
+class DocumentCache extends Model {
+
+  static get tableName() {
+    return 'document_cache';
+  }
+
+  $beforeUpdate() {
+    this.updatedAt = new Date().toISOString();
+  }
+
+  static load(id, fn, { timeout = 2000, ttl = 60 } = {}) {
+    return new Promise((resolve, reject) => {
+
+      this.query().findById(id)
+        .then(document => {
+          if (document) {
+            Object.defineProperty(document.document, 'cache', {
+              enumerable: false,
+              value: {
+                cached: true,
+                updatedAt: document.updatedAt
+              }
+            });
+            if (ttl && moment(document.updatedAt).isAfter(moment().subtract(ttl, 'seconds'))) {
+              return resolve(document.document);
+            }
+
+            setTimeout(() => {
+              resolve(document.document);
+            }, timeout);
+          }
+
+          return fn()
+            .then(document => {
+              return this.query().findById(id)
+                .then(model => {
+                  if (model) {
+                    return model.$query().patch({ document }).returning('*');
+                  }
+                  return this.query().insert({ id, document }).returning('*');
+                });
+            })
+            .then(document => {
+              Object.defineProperty(document.document, 'cache', {
+                enumerable: false,
+                value: {
+                  cached: false,
+                  updatedAt: document.updatedAt
+                }
+              });
+              resolve(document.document);
+            });
+
+        })
+        .catch(reject);
+
+    });
+
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['id'],
+      properties: {
+        id: { type: 'string' },
+        document: { type: [ 'null', 'object', 'array' ] },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' }
+      }
+    };
+  }
+}
+
+module.exports = DocumentCache;

--- a/schema/index.js
+++ b/schema/index.js
@@ -18,6 +18,7 @@ const AsruEstablishment = require('./asru-establishment');
 const ProjectProfile = require('./project-profile');
 const TrainingCourse = require('./training-course');
 const TrainingPil = require('./training-pil');
+const DocumentCache = require('./document-cache');
 
 module.exports = db => ({
   Authorisation: Authorisation.bindKnex(db),
@@ -39,5 +40,6 @@ module.exports = db => ({
   AsruEstablishment: AsruEstablishment.bindKnex(db),
   ProjectProfile: ProjectProfile.bindKnex(db),
   TrainingCourse: TrainingCourse.bindKnex(db),
-  TrainingPil: TrainingPil.bindKnex(db)
+  TrainingPil: TrainingPil.bindKnex(db),
+  DocumentCache: DocumentCache.bindKnex(db)
 });

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -8,6 +8,7 @@ const trainingCourses = require('./tables/training-courses');
 exports.seed = knex => {
   return Promise.resolve()
     .then(() => knex('establishment_merge_log').del())
+    .then(() => knex('document_cache').del())
     .then(() => knex('changelog').del())
     .then(() => knex('training_pils').del())
     .then(() => knex('training_courses').del())


### PR DESCRIPTION
Allows possibly slow functions to be cached in the database.

If a record has been generated in the 60 seconds then use that and do nothing else, otherwise try the query, and if it does not complete within 5 seconds then return the cached version, but allow the background function to continue and refresh the cache accordingly.