### PR TITLE
Add RCVS number to profile table

### DIFF
--- a/migrations/20201026155812_rcvs_number.js
+++ b/migrations/20201026155812_rcvs_number.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('profiles', table => {
+    table.string('rcvs_number');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('profiles', table => {
+    table.dropColumn('rcvs_number');
+  });
+};

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -77,6 +77,7 @@ class Profile extends BaseModel {
         qualifications: { type: ['string', 'null'] },
         certifications: { type: ['string', 'null'] },
         pilLicenceNumber: { type: ['string', 'null'] },
+        rcvsNumber: { type: ['string', 'null'] },
         address: { type: ['string', 'null'] },
         postcode: { type: ['string', 'null'] },
         telephone: { type: ['string', 'null'] },


### PR DESCRIPTION
This should be collected and displayed for people who hold NVS roles.

Given some users are NVS at _many_ establishments it makes sense for this to be attached to the profile so it can be persisted.