### PR TITLE
Include projects with additional availability in `profile.projects`

### DIFF
--- a/schema/profile.js
+++ b/schema/profile.js
@@ -481,7 +481,10 @@ class Profile extends BaseModel {
           to: 'projects.licenceHolderId'
         },
         filter: f => {
-          return f.skipUndefined().where('establishmentId', f.context().establishmentId);
+          if (!f.context().establishmentId) {
+            return;
+          }
+          return f.whereHasAvailability(f.context().establishmentId);
         }
       },
       asru: {

--- a/test/functional/helpers/db.js
+++ b/test/functional/helpers/db.js
@@ -6,6 +6,7 @@ const tables = [
   'TrainingPil',
   'TrainingCourse',
   'AsruEstablishment',
+  'ProjectEstablishment',
   'ProjectProfile',
   'ProjectVersion',
   'Project',
@@ -28,7 +29,12 @@ module.exports = {
   init: () => Schema(settings.connection),
   clean: schema => {
     return tables.reduce((p, table) => {
-      return p.then(() => schema[table].queryWithDeleted().hardDelete());
+      return p.then(() => {
+        if (typeof schema[table].queryWithDeleted === 'function') {
+          return schema[table].queryWithDeleted().hardDelete();
+        }
+        return schema[table].query().delete();
+      });
     }, Promise.resolve());
   }
 };

--- a/test/functional/profile/index.js
+++ b/test/functional/profile/index.js
@@ -1,6 +1,6 @@
 const uuid = require('uuid/v4');
 const assert = require('assert');
-const db = require('./helpers/db');
+const db = require('../helpers/db');
 
 const PROJECT_ID = uuid();
 const TRAINEE_ID = uuid();

--- a/test/functional/profile/projects.js
+++ b/test/functional/profile/projects.js
@@ -1,0 +1,173 @@
+const uuid = require('uuid/v4');
+const assert = require('assert');
+const db = require('../helpers/db');
+
+const ids = {
+  profile: {
+    regular: uuid(),
+    additional: uuid()
+  },
+  project: {
+    draftAdditional: uuid(),
+    grantedAdditional: uuid(),
+    regular: uuid()
+  },
+  version: {
+    granted: uuid(),
+    draftAdditional: uuid(),
+    grantedAdditional: uuid()
+  }
+};
+
+describe('Profile Projects', () => {
+
+  before(() => {
+    this.models = db.init();
+  });
+
+  before(() => {
+    return Promise.resolve()
+      .then(() => db.clean(this.models))
+      .then(() => this.models.Establishment.query().insert([
+        {
+          id: 111,
+          name: 'An establishment'
+        },
+        {
+          id: 222,
+          name: 'Another establishment'
+        }
+      ]))
+      .then(() => this.models.Profile.query().insert([
+        {
+          id: ids.profile.regular,
+          firstName: 'Project',
+          lastName: 'Holder',
+          email: 'ph@example.com'
+        },
+        {
+          id: ids.profile.additional,
+          firstName: 'Additional',
+          lastName: 'Holder',
+          email: 'ah@example.com'
+        }
+      ]))
+      .then(() => this.models.Permission.query().insert([
+        {
+          profileId: ids.profile.regular,
+          establishmentId: 111,
+          role: 'basic'
+        },
+        {
+          profileId: ids.profile.regular,
+          establishmentId: 222,
+          role: 'basic'
+        },
+        {
+          profileId: ids.profile.additional,
+          establishmentId: 111,
+          role: 'basic'
+        },
+        {
+          profileId: ids.profile.additional,
+          establishmentId: 222,
+          role: 'basic'
+        }
+      ]).returning('*'))
+      .then(() => this.models.Project.query().insertGraph([
+        {
+          id: ids.project.regular,
+          licenceHolderId: ids.profile.regular,
+          establishmentId: 111,
+          title: 'Ordinary project',
+          status: 'active'
+        },
+        {
+          id: ids.project.draftAdditional,
+          licenceHolderId: ids.profile.additional,
+          establishmentId: 111,
+          title: 'Draft additional project',
+          status: 'active',
+          version: [
+            {
+              id: ids.version.granted,
+              status: 'granted'
+            },
+            {
+              id: ids.version.draftAdditional,
+              status: 'draft'
+            }
+          ]
+        },
+        {
+          id: ids.project.grantedAdditional,
+          licenceHolderId: ids.profile.additional,
+          establishmentId: 222,
+          title: 'Granted additional project',
+          status: 'active',
+          version: [
+            {
+              id: ids.version.grantedAdditional,
+              status: 'granted'
+            }
+          ]
+        }
+      ]))
+      .then(() => this.models.ProjectEstablishment.query().insert([
+        {
+          projectId: ids.project.draftAdditional,
+          establishmentId: 222,
+          versionId: ids.version.draftAdditional,
+          status: 'draft'
+        },
+        {
+          projectId: ids.project.grantedAdditional,
+          establishmentId: 111,
+          versionId: ids.version.grantedAdditional,
+          status: 'active'
+        }
+      ]));
+  });
+
+  after(() => {
+    return db.clean(this.models);
+  });
+
+  after(() => {
+    return this.models.destroy();
+  });
+
+  it('shows projects held at the scoped establishment', () => {
+    return this.models.Profile.get({ establishmentId: 111, id: ids.profile.regular })
+      .then(profile => {
+        assert.deepEqual(profile.projects.map(p => p.title), ['Ordinary project']);
+      });
+  });
+
+  it('does not show projects held other than at the scoped establishment', () => {
+    return this.models.Profile.get({ establishmentId: 222, id: ids.profile.regular })
+      .then(profile => {
+        assert.deepEqual(profile.projects.map(p => p.title), []);
+      });
+  });
+
+  it('shows projects with additional availability at the scoped establishment', () => {
+    return this.models.Profile.get({ establishmentId: 111, id: ids.profile.additional })
+      .then(profile => {
+        assert.deepEqual(profile.projects.map(p => p.title), [
+          'Draft additional project',
+          'Granted additional project'
+        ]);
+      });
+  });
+
+  it('does not show projects with draft amendments to add additional availability', () => {
+    return this.models.Profile.get({ establishmentId: 222, id: ids.profile.additional })
+      .then(profile => {
+        assert.deepEqual(profile.projects.map(p => p.title), [
+          'Granted additional project'
+        ]);
+      });
+  });
+
+});


### PR DESCRIPTION
When calling `Profile.get()` in an establishment scoped query, include any projects in the related graph which have additional availability at the scoped establishment.

In order to do this, refactor the Project model to expose some additional query methods on the query builder class to support availability queries from outside the model - specifically in the `filter` property on the Profile=>Project relation.

Add a whole bunch of unit tests for all of this.