### PR TITLE
Include scoped additional establishment data on profile projects

### DIFF
--- a/schema/profile.js
+++ b/schema/profile.js
@@ -129,8 +129,17 @@ class Profile extends BaseModel {
       query.scopeToEstablishment('establishments.id', establishmentId);
     }
     return query
-      .withGraphFetched('[roles.places, establishments, pil(getLicenceNumber).establishment, projects, certificates, exemptions, asru, trainingPils.trainingCourse.[establishment, project]]')
+      .withGraphFetched('[roles.places, establishments, pil(getLicenceNumber).establishment, projects.additionalEstablishments(getEstablishment), certificates, exemptions, asru, trainingPils.trainingCourse.[establishment, project]]')
       .modifiers({
+        getEstablishment: builder => {
+          builder.select([
+            'establishments.id',
+            'establishments.name'
+          ]);
+          if (establishmentId) {
+            builder.where({ 'establishments.id': establishmentId });
+          }
+        },
         getLicenceNumber: builder => {
           builder.select([
             'pils.*',


### PR DESCRIPTION
When retrieving the projects associated with a profile, also include any additional establishments that are in line with the query's scope.