### PR TITLE
Allow changelog.changed_by to be nullable

### DIFF
--- a/migrations/20201120094528_nullable_changelog_changedby.js
+++ b/migrations/20201120094528_nullable_changelog_changedby.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.alterTable('changelog', table => {
+    table.uuid('changed_by').nullable().alter();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('changelog', table => {
+    table.uuid('changed_by').notNullable().alter();
+  });
+};


### PR DESCRIPTION
In certain error scenarios the resolver tries to log an error into the changelog table, but without a user. This causes a second error to be thrown inside the error handler as the record cannot be inserted.

Allow the column to be null so the error record can be inserted with a null `changed_by` property.