### PR TITLE
Add a second inspector

### DIFF
--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -56,6 +56,18 @@
     "asruSupport": false
   },
   {
+    "title": "Dr",
+    "firstName": "Inspector",
+    "lastName": "Gadget",
+    "dob": "1985-09-24",
+    "email": "inspector.gadget@example.com",
+    "asruUser": true,
+    "asruAdmin": false,
+    "asruInspector": true,
+    "asruLicensing": false,
+    "asruSupport": false
+  },
+  {
     "id": "a942ffc7-e7ca-4d76-a001-0b5048a057d2",
     "userId": "dee8605d-2113-4411-8a0a-dc131af87a76",
     "title": "Miss",


### PR DESCRIPTION
I think the permissions/roles tests that add and remove roles from user `inspector` are interfering with other tests that use that user to perform tasks.

Add another inspector user to run the permissions management tests against so it doesn't interfere.