### PR TITLE
Return primary est name for projects on profile fetch

### DIFF
--- a/schema/profile.js
+++ b/schema/profile.js
@@ -130,7 +130,16 @@ class Profile extends BaseModel {
       query.scopeToEstablishment('establishments.id', establishmentId);
     }
     return query
-      .withGraphFetched('[roles.places, establishments, pil(getLicenceNumber).establishment, projects.[establishment(constrainEstParams), additionalEstablishments(getEstablishment)], certificates, exemptions, asru, trainingPils.trainingCourse.[establishment, project]]')
+      .withGraphFetched(`[
+        roles.places,
+        establishments,
+        pil(getLicenceNumber).establishment,
+        projects.[establishment(constrainEstParams), additionalEstablishments(getEstablishment)],
+        certificates,
+        exemptions,
+        asru,
+        trainingPils.trainingCourse.[establishment, project]
+      ]`)
       .modifiers({
         getEstablishment: builder => {
           builder.select([

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -130,7 +130,7 @@ class Profile extends BaseModel {
       query.scopeToEstablishment('establishments.id', establishmentId);
     }
     return query
-      .withGraphFetched('[roles.places, establishments, pil(getLicenceNumber).establishment, projects.additionalEstablishments(getEstablishment), certificates, exemptions, asru, trainingPils.trainingCourse.[establishment, project]]')
+      .withGraphFetched('[roles.places, establishments, pil(getLicenceNumber).establishment, projects.[establishment(constrainEstParams), additionalEstablishments(getEstablishment)], certificates, exemptions, asru, trainingPils.trainingCourse.[establishment, project]]')
       .modifiers({
         getEstablishment: builder => {
           builder.select([
@@ -147,7 +147,8 @@ class Profile extends BaseModel {
             'pils.*',
             'profile.pilLicenceNumber as licenceNumber'
           ]).joinRelation('profile');
-        }
+        },
+        constrainEstParams: builder => builder.select('id', 'name')
       });
   }
 


### PR DESCRIPTION
When viewing a profile at an establishment, the establishment the project licences are held at may differ to the current establishment, so we need the primary establishment name to be available on the project itself.