### PR TITLE
Limit expiry on seed to active projects

### DIFF
--- a/seeds/tables/projects.js
+++ b/seeds/tables/projects.js
@@ -24,7 +24,11 @@ module.exports = {
       })
     )
       .then(() => knex('projects').insert(projects.filter(p => p.licenceHolderId).map(p => omit(p, 'additionalEstablishments'))))
-      .then(() => knex('projects').where('expiryDate', '<', (new Date()).toISOString()).update({ status: 'expired' }));
+      .then(() => knex('projects')
+        .where('expiryDate', '<', (new Date()).toISOString())
+        .where({ status: 'active' })
+        .update({ status: 'expired' })
+      );
   },
   delete: knex => knex('projects').del()
 };


### PR DESCRIPTION
This is automatically updating _all_ projects with expiry dates in the past to expired on seed, even if they're already revoked.