### PR TITLE
Add completed protocol to seed project

### DIFF
--- a/seeds/data/project-versions.js
+++ b/seeds/data/project-versions.js
@@ -345,6 +345,9 @@ module.exports = [
       'other-establishments': true,
       establishments: [
         { 'establishment-id': 30001 }
+      ],
+      protocols: [
+        { title: 'First protocol', complete: true }
       ]
     },
     'status': 'granted'


### PR DESCRIPTION
There needs to be a completed protocol on the project or things get very confusing in the tests because there's multiple "continue" buttons and multiple UI to mark a thing as complete.

By setting the protocol to complete these ui elements only appear once.