### PR TITLE
Add granted licence seed for version comparison tests

### DIFF
--- a/seeds/data/project-versions.js
+++ b/seeds/data/project-versions.js
@@ -1069,5 +1069,13 @@ module.exports = [
       purpose: ['purpose-a', 'purpose-b', 'purpose-c', 'purpose-d', 'purpose-e', 'purpose-g'],
       'purpose-b': ['purpose-b1', 'purpose-b2', 'purpose-b3']
     }
+  },
+  {
+    projectId: 'a398cc56-ea40-46fa-856e-8915dd831c78',
+    status: 'granted',
+    data: {
+      title: 'Version comparison test amendment',
+      'project-aim': toRichText('Granted version')
+    }
   }
 ];

--- a/seeds/data/projects.json
+++ b/seeds/data/projects.json
@@ -802,9 +802,20 @@
   {
     "id": "7296249e-a719-4c2f-8115-8047b40091ac",
     "establishmentId": 8201,
-    "title": "Version comparison test",
+    "title": "Version comparison test application",
     "status": "inactive",
     "schemaVersion": 1,
     "licenceHolderId": "304235c0-1a83-49f0-87ca-b11b1ad1e147"
+  },
+  {
+    "id": "a398cc56-ea40-46fa-856e-8915dd831c78",
+    "establishmentId": 8201,
+    "title": "Version comparison test amendment",
+    "status": "active",
+    "issueDate": "2021-01-01",
+    "expiryDate": "2026-01-01",
+    "schemaVersion": 1,
+    "licenceHolderId": "304235c0-1a83-49f0-87ca-b11b1ad1e147",
+    "licenceNumber": "COMPARE"
   }
 ]


### PR DESCRIPTION
Adds a granted licence with one rich text field filled out to use as a starting point for testing the comparison windows in an amendment cycle.