### PR TITLE
Cast int postgres types to js numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const moment = require('moment');
 const TIMESTAMPTZ_OID = 1184;
 const TIMESTAMP_OID = 1114;
 const DATE_OID = 1082;
+const INT4_OID = 23;
+const INT8_OID = 20;
 
 const parseFn = val => {
   return val === null ? null : moment(val).toISOString();
@@ -17,9 +19,17 @@ const dateParseFn = val => {
   return val === null ? null : moment(val).format('YYYY-MM-DD');
 };
 
+const intParseFn = val => {
+  return val === null ? null : parseInt(val, 10);
+};
+
 types.setTypeParser(TIMESTAMPTZ_OID, parseFn);
 types.setTypeParser(TIMESTAMP_OID, parseFn);
 types.setTypeParser(DATE_OID, dateParseFn);
+
+// WARNING: numbers larger than Number.MAX_SAFE_INTEGER will overflow and give different results
+types.setTypeParser(INT4_OID, intParseFn);
+types.setTypeParser(INT8_OID, intParseFn);
 
 module.exports = connection => {
 

--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -34,8 +34,7 @@ class BaseModel extends Model {
     return (query || this.query())
       .where({ establishmentId })
       .countDistinct(`${this.tableName}.id`)
-      .then(results => results[0])
-      .then(result => parseInt(result.count, 10));
+      .then(results => results[0].count);
   }
 
   static upsert(model, where, transaction) {

--- a/schema/establishment.js
+++ b/schema/establishment.js
@@ -152,8 +152,7 @@ class Establishment extends BaseModel {
   static count() {
     return this.query()
       .countDistinct('establishments.id')
-      .then(results => results[0])
-      .then(result => parseInt(result.count, 10));
+      .then(results => results[0].count);
   }
 }
 

--- a/schema/invitation.js
+++ b/schema/invitation.js
@@ -37,8 +37,7 @@ class Invitation extends BaseModel {
     return this.query()
       .where({ establishmentId })
       .count()
-      .then(results => results[0])
-      .then(result => parseInt(result.count, 10));
+      .then(results => results[0].count);
   }
 
   static paginate({ establishmentId, sort = {}, limit, offset }) {

--- a/schema/procedure.js
+++ b/schema/procedure.js
@@ -79,8 +79,7 @@ class Procedure extends BaseModel {
     return this.query()
       .where({ ropId })
       .countDistinct('id')
-      .then(results => results[0])
-      .then(result => parseInt(result.count, 10));
+      .then(results => results[0].count);
   }
 
   static list({ ropId, sort = {}, limit, offset }) {

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -210,8 +210,7 @@ class Profile extends BaseModel {
     return query
       .scopeToEstablishment('establishments.id', establishmentId)
       .countDistinct('profiles.id')
-      .then(result => result[0])
-      .then(result => parseInt(result.count, 10));
+      .then(result => result[0].count);
   }
 
   static searchAndFilter({
@@ -370,8 +369,7 @@ class Profile extends BaseModel {
     const countAsruProfiles = this.query()
       .countDistinct('profiles.id')
       .where('asruUser', true)
-      .then(result => result[0])
-      .then(result => parseInt(result.count, 10));
+      .then(result => result[0].count);
 
     return Promise.all([
       Promise.resolve(filters),

--- a/schema/project.js
+++ b/schema/project.js
@@ -266,8 +266,7 @@ class Project extends BaseModel {
       .whereHasAvailability(establishmentId)
       .where(statusQuery(status))
       .countDistinct('projects.id')
-      .then(result => result[0])
-      .then(result => parseInt(result.count, 10));
+      .then(result => result[0].count);
   }
 
   static search({ query, establishmentId, search, status = 'active', sort = {}, limit, offset, isAsru, ropsStatus, ropsYear }) {


### PR DESCRIPTION
Postgres returns some integer types as strings to prevent overflow in the case of very large numbers.

As we don't currently deal with any numbers larger than Number.MAX_SAFE_INTEGER (9007199254740991) we can cast them to JS number.