### PR TITLE
Improve search matching in establishment people and project lists

### DIFF
--- a/migrations/20210324115653_unaccent_extension.js
+++ b/migrations/20210324115653_unaccent_extension.js
@@ -1,0 +1,8 @@
+
+exports.up = function(knex) {
+  return knex.schema.raw('create extension if not exists "unaccent"');
+};
+
+exports.down = function(knex) {
+  return knex.schema.raw('drop extension if exists "unaccent"');
+};

--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -1,43 +1,7 @@
 const { isUndefined } = require('lodash');
 const { Model } = require('objection');
+const QueryBuilder = require('./query-builder');
 const ValidationError = require('./validation-error');
-
-class SoftDeleteQueryBuilder extends Model.QueryBuilder {
-  delete() {
-    this.mergeContext({
-      softDelete: true
-    });
-
-    return this.patch({
-      deleted: this.knex().fn.now()
-    });
-  }
-
-  undelete() {
-    this.mergeContext({
-      undelete: true
-    });
-    return this.patch({
-      deleted: null
-    });
-  }
-
-  hardDelete() {
-    return super.delete();
-  }
-
-  scopeToEstablishment(column, establishmentId, role) {
-    const query = this.mergeContext({ establishmentId })
-      .joinRelation('establishments')
-      .where(column, establishmentId);
-
-    if (role) {
-      query.where({ role });
-    }
-
-    return query;
-  }
-}
 
 class BaseModel extends Model {
   $beforeUpdate() {
@@ -45,7 +9,7 @@ class BaseModel extends Model {
   }
 
   static get QueryBuilder() {
-    return SoftDeleteQueryBuilder;
+    return QueryBuilder;
   }
 
   static query(...args) {

--- a/schema/pil.js
+++ b/schema/pil.js
@@ -1,9 +1,9 @@
 const BaseModel = require('./base-model');
 const { pilStatuses } = require('@asl/constants');
 const { uuid } = require('../lib/regex-validation');
-const Profile = require('./profile');
+const QueryBuilder = require('./query-builder');
 
-class PILQueryBuilder extends BaseModel.QueryBuilder {
+class PILQueryBuilder extends QueryBuilder {
 
   whereBillable({ establishmentId, start, end }) {
     const year = parseInt(start.substr(0, 4), 10);
@@ -69,7 +69,7 @@ class PILQueryBuilder extends BaseModel.QueryBuilder {
 class PIL extends BaseModel {
 
   static get QueryBuilder() {
-    return PILQueryBuilder;
+    return PILQueryBuilder.mixin(QueryBuilder.NameSearch);
   }
 
   static get tableName() {
@@ -131,11 +131,7 @@ class PIL extends BaseModel {
           return builder
             .orWhere('profile.pilLicenceNumber', 'iLike', `%${search}%`)
             .orWhere(b => {
-              Profile.searchFullName({
-                search,
-                prefix: 'profile',
-                query: b
-              });
+              b.whereNameMatch(search, 'profile');
             });
         }
       });

--- a/schema/project.js
+++ b/schema/project.js
@@ -39,8 +39,7 @@ class ProjectQueryBuilder extends QueryBuilder {
     if (Array.isArray(search)) {
       search = search[0];
     }
-    const parts = search.split(' ').join(' & ');
-    const q = `to_tsvector(unaccent(projects.title)) @@ to_tsquery('${parts}')`;
+    const q = `to_tsvector(unaccent(projects.title)) @@ websearch_to_tsquery('${search}')`;
 
     return this.whereRaw(q);
   }

--- a/schema/query-builder/index.js
+++ b/schema/query-builder/index.js
@@ -1,0 +1,27 @@
+const { Model } = require('objection');
+
+const SoftDelete = require('./mixins/soft-delete');
+const NameSearch = require('./mixins/name-search');
+
+class QueryBuilder extends Model.QueryBuilder {
+
+  static mixin(mx) {
+    return mx(this);
+  }
+
+  scopeToEstablishment(column, establishmentId, role) {
+    const query = this.mergeContext({ establishmentId })
+      .joinRelation('establishments')
+      .where(column, establishmentId);
+
+    if (role) {
+      query.where({ role });
+    }
+
+    return query;
+  }
+}
+
+QueryBuilder.NameSearch = NameSearch;
+
+module.exports = QueryBuilder.mixin(SoftDelete);

--- a/schema/query-builder/mixins/name-search.js
+++ b/schema/query-builder/mixins/name-search.js
@@ -1,0 +1,17 @@
+module.exports = (Base) => {
+
+  class NameSearch extends Base {
+    whereNameMatch(search, prefix = 'profiles') {
+      if (Array.isArray(search)) {
+        search = search[0];
+      }
+      const parts = search.split(' ').join(' & ');
+      const q = `(to_tsvector(unaccent(${prefix}.first_name)) || to_tsvector(unaccent(${prefix}.last_name))) @@ to_tsquery('${parts}')`;
+
+      return this.whereRaw(q);
+    }
+  }
+
+  return NameSearch;
+
+};

--- a/schema/query-builder/mixins/name-search.js
+++ b/schema/query-builder/mixins/name-search.js
@@ -5,7 +5,7 @@ module.exports = (Base) => {
       if (Array.isArray(search)) {
         search = search[0];
       }
-      const parts = search.split(' ').join(' & ');
+      const parts = search.split(' ').map(p => `${p}:*`).join(' & ');
       const q = `(to_tsvector(unaccent(${prefix}.first_name)) || to_tsvector(unaccent(${prefix}.last_name))) @@ to_tsquery('${parts}')`;
 
       return this.whereRaw(q);

--- a/schema/query-builder/mixins/soft-delete.js
+++ b/schema/query-builder/mixins/soft-delete.js
@@ -1,0 +1,30 @@
+module.exports = (Base) => {
+
+  class Mixed extends Base {
+    delete() {
+      this.mergeContext({
+        softDelete: true
+      });
+
+      return this.patch({
+        deleted: this.knex().fn.now()
+      });
+    }
+
+    undelete() {
+      this.mergeContext({
+        undelete: true
+      });
+      return this.patch({
+        deleted: null
+      });
+    }
+
+    hardDelete() {
+      return super.delete();
+    }
+  }
+
+  return Mixed;
+
+};

--- a/test/functional/base-model.js
+++ b/test/functional/base-model.js
@@ -6,9 +6,6 @@ const db = require('./helpers/db');
 const BaseModel = require('../../schema/base-model');
 
 describe('Base Model', () => {
-  it('Has a custom QueryBuilder', () => {
-    assert.equal(BaseModel.QueryBuilder.name, 'SoftDeleteQueryBuilder');
-  });
 
   describe('Custom methods', () => {
     before(() => {


### PR DESCRIPTION
This moves from using `ilike` to postgres native text search capability for matching names and project titles.

This means we can normalise diacritic characters away when doing searches (i.e. Håsnø Pil will now be returned when searching for `hasno`) as well as being able to match non-adjacent keywords in project title searches.

Refactors query builder code so that we can re-use common query functions across multiple models.