### PR TITLE
Fix name search query to not break on control characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3713,6 +3713,11 @@
         "pg-cursor": "^2.0.1"
       }
     },
+    "pg-tsquery": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/pg-tsquery/-/pg-tsquery-8.2.0.tgz",
+      "integrity": "sha512-ye1GMhdWoQ+HLkJNgKuhh7UP2mWK+lYsIiR1NmHGxjE6659ellSux+doqBrbjKQvj+ZhBxyJ8wyER2++8730mQ=="
+    },
     "pg-types": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "objection": "^2.1.3",
     "pg": "^7.4.1",
     "pg-query-stream": "^2.0.1",
+    "pg-tsquery": "^8.2.0",
     "sinon": "^9.0.2",
     "slate": "^0.47.8",
     "uuid": "^3.3.2"

--- a/schema/project.js
+++ b/schema/project.js
@@ -39,9 +39,9 @@ class ProjectQueryBuilder extends QueryBuilder {
     if (Array.isArray(search)) {
       search = search[0];
     }
-    const q = `to_tsvector(unaccent(projects.title)) @@ websearch_to_tsquery('${search}')`;
+    const q = `to_tsvector('english', unaccent(projects.title)) @@ websearch_to_tsquery('english', unaccent(?))`;
 
-    return this.whereRaw(q);
+    return this.whereRaw(q, [search]);
   }
 
   whereIsCollaborator(profileId) {

--- a/schema/query-builder/mixins/name-search.js
+++ b/schema/query-builder/mixins/name-search.js
@@ -1,5 +1,5 @@
 const tsquery = require('pg-tsquery');
-const stringify = tsquery();
+const parse = tsquery();
 
 module.exports = (Base) => {
 
@@ -9,7 +9,7 @@ module.exports = (Base) => {
         search = search[0];
       }
 
-      const query = stringify(search.split(/\s|-/).map(p => p + '*').join(' '));
+      const query = parse(search.split(/\s|-/).map(p => p + '*').join(' '));
 
       // remove apostrophes and accented characters from names
       const tsvector = field => `to_tsvector('simple', unaccent(replace(${prefix}.${field}, '''', '')))`;

--- a/schema/query-builder/mixins/name-search.js
+++ b/schema/query-builder/mixins/name-search.js
@@ -9,7 +9,7 @@ module.exports = (Base) => {
         search = search[0];
       }
 
-      const query = stringify(search.split(' ').map(p => p + '*').join(' '));
+      const query = stringify(search.split(/\s|-/).map(p => p + '*').join(' '));
 
       // remove apostrophes and accented characters from names
       const tsvector = field => `to_tsvector('simple', unaccent(replace(${prefix}.${field}, '''', '')))`;

--- a/schema/query-builder/mixins/name-search.js
+++ b/schema/query-builder/mixins/name-search.js
@@ -1,3 +1,6 @@
+const tsquery = require('pg-tsquery');
+const stringify = tsquery();
+
 module.exports = (Base) => {
 
   class NameSearch extends Base {
@@ -5,10 +8,15 @@ module.exports = (Base) => {
       if (Array.isArray(search)) {
         search = search[0];
       }
-      const parts = search.split(' ').map(p => `${p}:*`).join(' & ');
-      const q = `(to_tsvector(unaccent(${prefix}.first_name)) || to_tsvector(unaccent(${prefix}.last_name))) @@ to_tsquery('${parts}')`;
 
-      return this.whereRaw(q);
+      const query = stringify(search.split(' ').map(p => p + '*').join(' '));
+
+      // remove apostrophes and accented characters from names
+      const tsvector = field => `to_tsvector('simple', unaccent(replace(${prefix}.${field}, '''', '')))`;
+
+      const sql = `(${tsvector('first_name')} || ${tsvector('last_name')}) @@ to_tsquery('simple', unaccent(?))`;
+
+      return this.whereRaw(sql, [query]);
     }
   }
 


### PR DESCRIPTION
* Pass input through `tsquery` lib in order to remove any query control characters.
* Remove apostrophes from tsvectors so names with apostrophes will match with and without them being in the search term
* Convert string injection of raw queries to parameterised queries to remove SQL injection vector