### PR TITLE
Remove websearch parsing of project title search input

### DIFF
--- a/schema/project.js
+++ b/schema/project.js
@@ -39,7 +39,7 @@ class ProjectQueryBuilder extends QueryBuilder {
     if (Array.isArray(search)) {
       search = search[0];
     }
-    const q = `to_tsvector('english', unaccent(projects.title)) @@ websearch_to_tsquery('english', unaccent(?))`;
+    const q = `to_tsvector('english', unaccent(projects.title)) @@ plainto_tsquery('english', unaccent(?))`;
 
     return this.whereRaw(q, [search]);
   }


### PR DESCRIPTION
This interprets hyphens in the input as negation operators, which is unexpected.

Use `plainto_tsquery` to handle the input instead which will safely convert the input to a search query, but without applying any additional logic.