### PR TITLE
Implement new database table for tracking requested exports

### DIFF
--- a/migrations/20210329114600_data_exports_table.js
+++ b/migrations/20210329114600_data_exports_table.js
@@ -1,0 +1,20 @@
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('exports', table => {
+      table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+      table.uuid('profile_id').references('id').inTable('profiles').notNull();
+      table.string('type').notNull();
+      table.index('type');
+      table.string('key').notNull();
+      table.index('key');
+      table.boolean('ready').defaultTo(false);
+      table.jsonb('meta');
+      table.dateTime('deleted');
+      table.timestamps(false, true);
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('exports');
+};

--- a/schema/export.js
+++ b/schema/export.js
@@ -1,0 +1,42 @@
+const BaseModel = require('./base-model');
+const { uuid } = require('../lib/regex-validation');
+
+class Export extends BaseModel {
+  static get tableName() {
+    return 'exports';
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string', pattern: uuid.v4 },
+        profileId: { type: 'string', pattern: uuid.v4 },
+        type: { type: 'string' },
+        key: { type: 'string' },
+        ready: { type: 'boolean' },
+        meta: { type: ['object', 'null'] },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' },
+        deleted: { type: ['string', 'null'], format: 'date-time' }
+      }
+    };
+  }
+
+  static get relationMappings() {
+    return {
+      profile: {
+        relation: this.BelongsToOneRelation,
+        modelClass: `${__dirname}/profile`,
+        join: {
+          from: 'exports.profileId',
+          to: 'profiles.id'
+        }
+      }
+    };
+  }
+
+}
+
+module.exports = Export;

--- a/schema/index.js
+++ b/schema/index.js
@@ -1,5 +1,6 @@
 const Authorisation = require('./authorisation');
 const Establishment = require('./establishment');
+const Export = require('./export');
 const Permission = require('./permission');
 const Invitation = require('./invitation');
 const PIL = require('./pil');
@@ -28,6 +29,7 @@ const Procedure = require('./procedure');
 module.exports = db => ({
   Authorisation: Authorisation.bindKnex(db),
   Establishment: Establishment.bindKnex(db),
+  Export: Export.bindKnex(db),
   Permission: Permission.bindKnex(db),
   Invitation: Invitation.bindKnex(db),
   PIL: PIL.bindKnex(db),

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -12,6 +12,7 @@ exports.seed = knex => {
     .then(() => knex('establishment_merge_log').del())
     .then(() => knex('document_cache').del())
     .then(() => knex('changelog').del())
+    .then(() => knex('exports').del())
     .then(() => knex('training_pils').del())
     .then(() => knex('training_courses').del())
     .then(() => knex('project_profiles').del())


### PR DESCRIPTION
* has relation to profile that requested
* `type` and `key` properties to set parameters for requested export - e.g. `type: 'rops', key: '2021'`
* has boolean `ready` field once export is available in S3
* metadata jsonb column to access arbitrary metadata related to the export