### PR TITLE
Bugfix/no empty inserts

### DIFF
--- a/lib/merge-establishments.js
+++ b/lib/merge-establishments.js
@@ -15,6 +15,9 @@ const merge = (knex, fromEstablishmentId, toEstablishmentId) => {
         .whereRaw('permissions.profile_id = profiles.id');
     })
     .then(profilesNeedingPerms => {
+      if (profilesNeedingPerms.length === 0) {
+        return;
+      }
       // add basic perms for all profiles not already associated with the target establishment
       const newPerms = profilesNeedingPerms.map(profile => ({
         profile_id: profile.id,
@@ -43,6 +46,9 @@ const merge = (knex, fromEstablishmentId, toEstablishmentId) => {
         .update({ establishment_id: toEstablishmentId }, ['id']) // returning the affected ids
         .where({ establishment_id: fromEstablishmentId })
         .then(pilsMoved => {
+          if (pilsMoved.length === 0) {
+            return;
+          }
           // log which pils were moved so we can rollback if required
           const mergeLog = pilsMoved.map(pil => ({
             model_type: 'pils',
@@ -67,7 +73,9 @@ const merge = (knex, fromEstablishmentId, toEstablishmentId) => {
             from_establishment_id: fromEstablishmentId,
             to_establishment_id: toEstablishmentId
           }));
-          return knex.insert(mergeLog).into('establishment_merge_log');
+          if (mergeLog.length > 0) {
+            return knex.insert(mergeLog).into('establishment_merge_log');
+          }
         });
     });
 };

--- a/migrations/20200501144545_move_nacwo_assignments_to_place_roles.js
+++ b/migrations/20200501144545_move_nacwo_assignments_to_place_roles.js
@@ -2,7 +2,11 @@
 exports.up = function(knex) {
   return Promise.resolve()
     .then(() => knex('places').select('id AS place_id', 'nacwo_id AS role_id').whereNotNull('nacwo_id'))
-    .then(nacwoAssignments => knex('place_roles').insert(nacwoAssignments));
+    .then(nacwoAssignments => {
+      if (nacwoAssignments.length > 0) {
+        return knex('place_roles').insert(nacwoAssignments);
+      }
+    });
 };
 
 exports.down = function(knex) {

--- a/migrations/20201006111459_pil-e-fee-waivers.js
+++ b/migrations/20201006111459_pil-e-fee-waivers.js
@@ -38,7 +38,9 @@ exports.up = function(knex) {
         );
     })
     .then(waivers => {
-      return knex('pil_fee_waivers').insert(waivers);
+      if (waivers.length > 0) {
+        return knex('pil_fee_waivers').insert(waivers);
+      }
     });
 };
 


### PR DESCRIPTION
From https://github.com/knex/knex/blob/master/UPGRADING.md:

>Trying to execute an operation resulting in an empty query such as inserting an empty array, will now throw an error on all database drivers.

As CI starts from a schemaless db, all the migrations are run every time so we need to fix the old migrations to not insert empty arrays.