### PR TITLE
Add seed for internal amendment test

### DIFF
--- a/seeds/data/project-versions.js
+++ b/seeds/data/project-versions.js
@@ -1318,6 +1318,15 @@ module.exports = [
     updatedAt: '2020-10-01'
   },
   {
+    projectId: '209696c6-13ac-4297-911d-bbce28954a62',
+    data: {
+      'title': 'Internal amendment test'
+    },
+    status: 'granted',
+    createdAt: '2020-10-01',
+    updatedAt: '2020-10-01'
+  },
+  {
     projectId: '46c41498-5e2b-4949-956d-e0159d89b78c',
     data: {
       'title': 'Content search - continuation',

--- a/seeds/data/projects.json
+++ b/seeds/data/projects.json
@@ -1159,5 +1159,16 @@
     "schemaVersion": 1,
     "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd",
     "licenceNumber": "ROPGAAS"
+  },
+  {
+    "id": "209696c6-13ac-4297-911d-bbce28954a62",
+    "establishmentId": 8201,
+    "title": "Internal amendment test",
+    "status": "active",
+    "issueDate": "2021-03-01",
+    "expiryDate": "2026-03-01",
+    "schemaVersion": 1,
+    "licenceHolderId": "5b7bad13-f34b-4959-bd08-c6067ae2fcdd",
+    "licenceNumber": "INTAMEND"
   }
 ]


### PR DESCRIPTION
Currently `Active project` is being used for a lot of different tests, which means having complex teardown code in tests to avoid cross-dependencies. Create a new seed for internal amendment to avoid this.