### PR TITLE
Include removed AA relations when listing projects

### DIFF
--- a/schema/project.js
+++ b/schema/project.js
@@ -308,7 +308,7 @@ class Project extends BaseModel {
         constrainAAParams: builder => {
           builder.select('id', 'name', 'projectEstablishments.status');
           if (status !== 'inactive') {
-            builder.where('projectEstablishments.status', 'active');
+            builder.whereIn('projectEstablishments.status', ['active', 'removed']);
           }
         },
         constrainEstParams: builder => builder.select('id', 'name')

--- a/test/functional/helpers/db.js
+++ b/test/functional/helpers/db.js
@@ -7,6 +7,8 @@ const tables = [
   'TrainingCourse',
   'AsruEstablishment',
   'ProjectEstablishment',
+  'Procedure',
+  'Rop',
   'ProjectProfile',
   'ProjectVersion',
   'Project',

--- a/test/functional/project.js
+++ b/test/functional/project.js
@@ -289,6 +289,61 @@ describe('Project model', () => {
         });
     });
 
+    it('includes removed aa for active projects', () => {
+      const opts = {
+        establishmentId: ids.establishmentId,
+        status: 'active',
+        search: 'Additional availability'
+      };
+
+      const projEst = {
+        projectId: ids.additionalProject,
+        establishmentId: ids.additionalEstablishment,
+        status: 'removed',
+        versionId: ids.additionalVersion
+      };
+
+      return Promise.resolve()
+        .then(() => this.models.ProjectEstablishment.query().insert(projEst))
+        .then(() => this.models.Project.search(opts))
+        .then(results => results.results[0])
+        .then(project => {
+          assert.equal(project.additionalEstablishments.length, 1);
+          assert.equal(project.additionalEstablishments[0].id, ids.additionalEstablishment);
+          assert.equal(project.additionalEstablishments[0].status, 'removed');
+        });
+    });
+
+    it('includes removed aa for active projects when searching from the removed establishment', () => {
+      const opts = {
+        establishmentId: ids.additionalEstablishment,
+        status: 'active',
+        search: 'Additional availability',
+        // add a sort so that the first project is not `Draft additional availability`
+        sort: {
+          column: 'title',
+          ascending: 'true'
+        }
+      };
+
+      const projEst = {
+        projectId: ids.additionalProject,
+        establishmentId: ids.additionalEstablishment,
+        status: 'removed',
+        versionId: ids.additionalVersion
+      };
+
+      return Promise.resolve()
+        .then(() => this.models.ProjectEstablishment.query().insert(projEst))
+        .then(() => this.models.Project.search(opts))
+        .then(results => results.results[0])
+        .then(project => {
+          assert.equal(project.additionalEstablishments.length, 1);
+          assert.equal(project.additionalEstablishments[0].id, ids.additionalEstablishment);
+          assert.equal(project.additionalEstablishments[0].status, 'removed');
+        });
+    });
+
     it('includes draft aa for draft projects', () => {
       const opts = {
         establishmentId: 8201,


### PR DESCRIPTION
Otherwise the status will not show correctly when the project appears in the additional establishment's project list.