### PR TITLE
Explicit arguments to `JSON.stringify`

### DIFF
--- a/migrations/20210727160551_migrate_rops_other_to_objects.js
+++ b/migrations/20210727160551_migrate_rops_other_to_objects.js
@@ -113,7 +113,7 @@ exports.up = function(knex) {
               return Promise.resolve();
             }
             return Promise.resolve()
-              .then(() => knex('rops').where({ id: rop.id }).update(mapValues(updates, JSON.stringify)))
+              .then(() => knex('rops').where({ id: rop.id }).update(mapValues(updates, value => JSON.stringify(value))))
               .then(() => knex('procedures').where({ rop_id: rop.id }))
               .then(procs => {
                 return procs.reduce((procPromise, proc) => {


### PR DESCRIPTION
`mapValues` calls iterator functions with three arguments, and the second and third arguments to `JSON.stringify` affect the output, so make sure we don't have any accidental side-effects from passing them.