### PR TITLE
Set country field to `england` where it is missing

### DIFF
--- a/migrations/20210831142321_backfill_country_field.js
+++ b/migrations/20210831142321_backfill_country_field.js
@@ -1,0 +1,8 @@
+
+exports.up = function(knex) {
+  return knex('establishments').update({ country: 'england' }).whereNull('country');
+};
+
+exports.down = function(knex) {
+  return Promise.resolve();
+};


### PR DESCRIPTION
I've looked at the  data in prod with missing country fields and they're all in England, so this is the easiest way to fill the missing data.