### PR TITLE
Remove the not null constraint on exports.profile_id

### DIFF
--- a/migrations/20220114161946_remove_exports_profile_id_not_null_constraint.js
+++ b/migrations/20220114161946_remove_exports_profile_id_not_null_constraint.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.alterTable('exports', table => {
+    table.uuid('profile_id').nullable().alter();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.alterTable('exports', table => {
+    table.uuid('profile_id').notNullable().alter();
+  });
+};


### PR DESCRIPTION
Task metrics exports are automatically generated by the `data-exports` service and do not have an associated profile.