### PR TITLE
Add historical task-metrics data-exports

### DIFF
--- a/seeds/index.js
+++ b/seeds/index.js
@@ -6,9 +6,11 @@ const projectVersions = require('./tables/project-versions');
 const additionalAvailability = require('./tables/additional-availability');
 const trainingCourses = require('./tables/training-courses');
 const rops = require('./tables/rops');
+const dataExports = require('./tables/exports');
 
 exports.seed = knex => {
   return Promise.resolve()
+    .then(() => dataExports.delete(knex))
     .then(() => knex('establishment_merge_log').del())
     .then(() => knex('document_cache').del())
     .then(() => knex('changelog').del())
@@ -39,5 +41,6 @@ exports.seed = knex => {
     .then(() => projectVersions.populate(knex))
     .then(() => additionalAvailability.populate(knex))
     .then(() => trainingCourses.populate(knex))
-    .then(() => rops.populate(knex));
+    .then(() => rops.populate(knex))
+    .then(() => dataExports.populate(knex));
 };

--- a/seeds/tables/exports.js
+++ b/seeds/tables/exports.js
@@ -1,0 +1,29 @@
+const moment = require('moment');
+
+const generateExports = () => {
+  const earliest = moment('2021-05-01');
+  const latest = moment().subtract(1, 'month').startOf('month');
+  let date = earliest;
+  const dataExports = [];
+
+  // eslint-disable-next-line no-unmodified-loop-condition
+  while (date <= latest) {
+    dataExports.push({
+      type: 'task-metrics',
+      key: date.format('YYYY-MM'),
+      ready: false,
+      meta: {
+        start: date.format('YYYY-MM-DD'),
+        end: moment(date).endOf('month').format('YYYY-MM-DD')
+      }
+    });
+    date.add(1, 'month');
+  }
+
+  return dataExports;
+};
+
+module.exports = {
+  populate: knex => knex('exports').insert(generateExports()),
+  delete: knex => knex('exports').del()
+};


### PR DESCRIPTION
Add some data-exports seeds for the task-metrics report, starting from May 2021 until the month before now.

Most of the stats will be zero as most of the task seeds are dated from the seed date