### PR TITLE
Fix ROPs due date calculation query

### DIFF
--- a/schema/project.js
+++ b/schema/project.js
@@ -113,9 +113,9 @@ class ProjectQueryBuilder extends QueryBuilder {
 
     return this.select(this.knex().raw(`
       CASE
-        WHEN projects.status = 'active' THEN LEAST('${endOfJanNextYear}'::timestamptz, DATE_TRUNC('day', projects.expiry_date) + ${interval28Days})
-        WHEN projects.status = 'expired' THEN DATE_TRUNC('day', projects.expiry_date) + ${interval28Days}
-        WHEN projects.status = 'revoked' THEN DATE_TRUNC('day', projects.revocation_date) + ${interval28Days}
+        WHEN (projects.status = 'expired' and DATE_TRUNC('day', projects.expiry_date) <= '${year}-12-31') THEN DATE_TRUNC('day', projects.expiry_date) + ${interval28Days}
+        WHEN (projects.status = 'revoked' and DATE_TRUNC('day', projects.revocation_date) <= '${year}-12-31') THEN DATE_TRUNC('day', projects.revocation_date) + ${interval28Days}
+        ELSE LEAST('${endOfJanNextYear}'::timestamptz, DATE_TRUNC('day', projects.expiry_date) + ${interval28Days})
       END rops_deadline
     `));
   }


### PR DESCRIPTION
Returns for 2021 on projects which have expired or been revoked in early 2022 were showing a due date of expiry/revocation + 28 days (i.e. some time in February) despite the fact that the correct due date for 2021 returns is 31st january because the projects were still active at the end of the year.

Update the query so that expired and revoked projects only have a due date of "end date + 28 days" if they ended before the end of the ROPs year.