### PR TITLE
Don't include deleted roles in place join

### DIFF
--- a/schema/place.js
+++ b/schema/place.js
@@ -10,7 +10,7 @@ class PlaceQueryBuilder extends BaseModel.QueryBuilder {
       .leftJoinRelated('roles.profile')
       .withGraphFetched('roles(notDeleted).profile(constrainProfileParams)')
       .modifiers({
-        notDeleted: builder => builder.whereNull('placeRoles.deleted'),
+        notDeleted: builder => builder.whereNull('placeRoles.deleted').whereNull('roles.deleted'),
         constrainProfileParams: builder => builder.select('id', 'firstName', 'lastName')
       });
   }


### PR DESCRIPTION
When building the search index for places it is preserving the role assignments even once the person has been removed from the role. In theory the place assignments should be deleted at the point of removing the role, but there's some lingering ones from before the code change that are shwoing up weirdly. Filter those out in the query.