### PR TITLE
Update `.whereRopsDue()` query method to include transfers

### DIFF
--- a/schema/project.js
+++ b/schema/project.js
@@ -77,7 +77,17 @@ class ProjectQueryBuilder extends QueryBuilder {
     return this.where('projects.issueDate', '<=', `${year}-12-31`)
       .andWhere(builder => {
         builder
+          .whereNull('projects.transferredInDate')
+          .orWhere('projects.transferredInDate', '<=', `${year}-12-31`);
+      })
+      .andWhere(builder => {
+        builder
           .where('projects.status', 'active')
+          .orWhere(qb => {
+            qb
+              .where('projects.status', 'transferred')
+              .where('projects.transferredOutDate', '>=', `${year}-12-31`);
+          })
           .orWhere(qb => {
             qb
               .where('projects.status', 'expired')


### PR DESCRIPTION
Projects transferred out of an establishment should still show ROPs due for years before the transfer, and similarly projects transferred into an establishment should not be due ROPs until after the transfer.

There is currently a project that was transferred in February 2022, which is showing as needing a 2021 ROP at it's current (new) establishment, but not at the old one.