### PR TITLE
context() behaves the same as deprecated mergeContext()

### DIFF
--- a/schema/query-builder/index.js
+++ b/schema/query-builder/index.js
@@ -10,7 +10,7 @@ class QueryBuilder extends Model.QueryBuilder {
   }
 
   scopeToEstablishment(column, establishmentId, role) {
-    const query = this.mergeContext({ establishmentId })
+    const query = this.context({ establishmentId })
       .joinRelation('establishments')
       .where(column, establishmentId);
 

--- a/schema/query-builder/mixins/soft-delete.js
+++ b/schema/query-builder/mixins/soft-delete.js
@@ -2,7 +2,7 @@ module.exports = (Base) => {
 
   class Mixed extends Base {
     delete() {
-      this.mergeContext({
+      this.context({
         softDelete: true
       });
 
@@ -12,7 +12,7 @@ module.exports = (Base) => {
     }
 
     undelete() {
-      this.mergeContext({
+      this.context({
         undelete: true
       });
       return this.patch({


### PR DESCRIPTION
`mergeContext()` spams deprecation warnings, replace it with `context()` which behaves in the same way.

https://vincit.github.io/objection.js/release-notes/migration.html#context-now-acts-like-mergecontext