### PR TITLE
Allow update actions to not touch `updated_at` timestamp

### DIFF
--- a/schema/base-model.js
+++ b/schema/base-model.js
@@ -4,8 +4,10 @@ const QueryBuilder = require('./query-builder');
 const ValidationError = require('./validation-error');
 
 class BaseModel extends Model {
-  $beforeUpdate() {
-    this.updatedAt = new Date().toISOString();
+  $beforeUpdate(opt, context) {
+    if (!context.preserveUpdatedAt) {
+      this.updatedAt = new Date().toISOString();
+    }
   }
 
   static get QueryBuilder() {

--- a/test/functional/base-model.js
+++ b/test/functional/base-model.js
@@ -26,11 +26,13 @@ describe('Base Model', () => {
             {
               id: '6d9c921f-ac0d-401b-ace4-e4d55b4ea2d2',
               type: 'killing',
-              method: 'captive bolt'
+              method: 'captive bolt',
+              updatedAt: '2019-10-01T12:00:00.000Z'
             },
             {
               id: '561dfe21-fc2a-420f-8bb6-100b1f1e2735',
-              type: 'rehomes'
+              type: 'rehomes',
+              updatedAt: '2019-10-01T12:00:00.000Z'
             }
           ]);
         });
@@ -97,6 +99,28 @@ describe('Base Model', () => {
             assert.deepEqual(model, undefined);
           });
       });
+    });
+
+    describe('preserveUpdatedAt', () => {
+
+      it('updates the `updatedAt` timestamp to now by default', () => {
+        return Promise.resolve()
+          .then(() => this.Model.query().update({ type: 'rehomes' }).where({ id: '6d9c921f-ac0d-401b-ace4-e4d55b4ea2d2' }))
+          .then(() => this.Model.query().findById('6d9c921f-ac0d-401b-ace4-e4d55b4ea2d2'))
+          .then(model => {
+            assert.equal(model.updatedAt.split('T')[0], new Date().toISOString().split('T')[0]);
+          });
+      });
+
+      it('preserves the `updatedAt` timestamp if `preserveUpdatedAt` context is set', () => {
+        return Promise.resolve()
+          .then(() => this.Model.query().context({ preserveUpdatedAt: true }).update({ type: 'rehomes' }).where({ id: '6d9c921f-ac0d-401b-ace4-e4d55b4ea2d2' }))
+          .then(() => this.Model.query().findById('6d9c921f-ac0d-401b-ace4-e4d55b4ea2d2'))
+          .then(model => {
+            assert.equal(model.updatedAt.split('T')[0], '2019-10-01');
+          });
+      });
+
     });
 
     describe('upsert', () => {


### PR DESCRIPTION
There are some actions (specifically updating the billing information on an establishment) which we want to not cause the `updated_at` timestamp to update. In this case because it causes the PEL to show an "amended date" that doesn't correspond to an amendment.

Add an option to a query to ignore this timestamp as required.