### PR TITLE
Add suspend date to licences

### DIFF
--- a/migrations/20220816123015_suspend_licence.js
+++ b/migrations/20220816123015_suspend_licence.js
@@ -1,0 +1,12 @@
+
+exports.up = async function(knex) {
+  await knex.schema.table('establishments', table => table.dateTime('suspended_date').nullable());
+  await knex.schema.table('projects', table => table.dateTime('suspended_date').nullable());
+  await knex.schema.table('pils', table => table.dateTime('suspended_date').nullable());
+};
+
+exports.down = async function(knex) {
+  await knex.schema.table('establishments', table => table.dropColumn('suspended_date'));
+  await knex.schema.table('projects', table => table.dropColumn('suspended_date'));
+  await knex.schema.table('pils', table => table.dropColumn('suspended_date'));
+};

--- a/schema/establishment.js
+++ b/schema/establishment.js
@@ -32,6 +32,7 @@ class Establishment extends BaseModel {
         status: { type: 'string', enum: establishmentStatuses },
         issueDate: { type: ['string', 'null'], format: 'date-time' },
         revocationDate: { type: ['string', 'null'], format: 'date-time' },
+        suspendedDate: { type: ['string', 'null'], format: 'date-time' },
         licenceNumber: { type: ['string', 'null'] },
         sharedKey: { type: ['string', 'null'] },
         country: { type: 'string', enum: establishmentCountries },

--- a/schema/pil.js
+++ b/schema/pil.js
@@ -88,6 +88,7 @@ class PIL extends BaseModel {
         issueDate: { type: ['string', 'null'], format: 'date-time' },
         revocationDate: { type: ['string', 'null'], format: 'date-time' },
         reviewDate: { type: ['string', 'null'], format: 'date-time' },
+        suspendedDate: { type: ['string', 'null'], format: 'date-time' },
         licenceNumber: { type: ['string', 'null'] },
         conditions: { type: ['string', 'null'] },
         createdAt: { type: 'string', format: 'date-time' },

--- a/schema/project.js
+++ b/schema/project.js
@@ -198,6 +198,7 @@ class Project extends BaseModel {
         raDate: { type: ['string', 'null'], format: 'date-time' },
         raGrantedDate: { type: ['string', 'null'], format: 'date-time' },
         refusedDate: { type: ['string', 'null'], format: 'date-time' },
+        suspendedDate: { type: ['string', 'null'], format: 'date-time' },
         licenceNumber: { type: ['string', 'null'] },
         createdAt: { type: 'string', format: 'date-time' },
         updatedAt: { type: 'string', format: 'date-time' },

--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -1133,6 +1133,7 @@
     }
   },
   {
+    "id":"cef52399-5e40-44f1-b7d1-ce840da9847c",
     "permissions": [
       {
         "establishmentId": 8201


### PR DESCRIPTION
Adds a new timestamp column to pils / projects / establishments for storing the suspended date.

Suspended licences will have it set, null for all other licences (including reinstated after suspension).