### PR TITLE
Former ASRU staff query

### DIFF
--- a/migrations/20221018083857_changelog_idx.js
+++ b/migrations/20221018083857_changelog_idx.js
@@ -1,0 +1,16 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('changelog', table => {
+    table.index('model_type');
+    table.index('model_id');
+    table.index('action');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('changelog', table => {
+    table.dropIndex('action');
+    table.dropIndex('model_id');
+    table.dropIndex('model_type');
+  });
+};

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -398,7 +398,10 @@ class Profile extends BaseModel {
       .whereIn('modelId', asruUserAdded)
       .as('asruRemoved');
 
-    const query = this.query().innerJoin(asruUserRemoved, 'profiles.id', 'asruRemoved.id');
+    const query = this.query()
+      .innerJoin(asruUserRemoved, 'profiles.id', 'asruRemoved.id')
+      .where({ asruUser: false });
+
     const countQuery = query.clone().count();
 
     let profilesQuery = query.select('profiles.*', 'asruRemoved.removedAt');

--- a/schema/profile.js
+++ b/schema/profile.js
@@ -1,6 +1,7 @@
 const { ref } = require('objection');
 const { compact, remove } = require('lodash');
 const BaseModel = require('./base-model');
+const Changelog = require('./changelog');
 const TrainingPil = require('./training-pil');
 const Role = require('./role');
 const Permission = require('./permission');
@@ -378,6 +379,47 @@ class Profile extends BaseModel {
       Promise.resolve(filters),
       countAsruProfiles,
       this.searchAndFilterAsru(params)
+    ])
+      .then(([filters, total, profiles]) => ({ filters, total, profiles }));
+  }
+
+  static getFormerAsruProfiles(params) {
+    const { search, limit, offset, sort = {} } = params;
+
+    const asruUserAdded = Changelog.query()
+      .select('modelId')
+      .where({ modelType: 'profile', action: 'update' })
+      .whereJsonSupersetOf('state', { asruUser: true });
+
+    const asruUserRemoved = Changelog.query()
+      .select(this.raw('uuid(model_id) AS id'))
+      .select('updatedAt AS removedAt')
+      .whereJsonSupersetOf('state', { asruUser: false })
+      .whereIn('modelId', asruUserAdded)
+      .as('asruRemoved');
+
+    const query = this.query().innerJoin(asruUserRemoved, 'profiles.id', 'asruRemoved.id');
+    const countQuery = query.clone().count();
+
+    let profilesQuery = query.select('profiles.*', 'asruRemoved.removedAt');
+
+    if (search) {
+      profilesQuery.where('email', 'iLike', search && `%${search}%`)
+        .orWhere(builder => builder.whereNameMatch(search));
+    }
+
+    if (sort.column) {
+      profilesQuery = this.orderBy({ query: profilesQuery, sort });
+    } else {
+      profilesQuery.orderBy('lastName');
+    }
+
+    profilesQuery = this.paginate({ query: profilesQuery, limit, offset });
+
+    return Promise.all([
+      Promise.resolve({}),
+      countQuery.then(results => results[0].count),
+      profilesQuery
     ])
       .then(([filters, total, profiles]) => ({ filters, total, profiles }));
   }

--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -88,6 +88,58 @@
     "asruRops": false
   },
   {
+    "title": "Mr",
+    "firstName": "Asru",
+    "lastName": "Temp 1",
+    "dob": "1970-09-01",
+    "email": "asru.temp1@example.com",
+    "asruUser": false,
+    "asruAdmin": false,
+    "asruInspector": false,
+    "asruLicensing": false,
+    "asruSupport": false,
+    "asruRops": false
+  },
+  {
+    "title": "Mr",
+    "firstName": "Asru",
+    "lastName": "Temp 2",
+    "dob": "1970-09-02",
+    "email": "asru.temp2@example.com",
+    "asruUser": false,
+    "asruAdmin": false,
+    "asruInspector": false,
+    "asruLicensing": false,
+    "asruSupport": false,
+    "asruRops": false
+  },
+  {
+    "title": "Mr",
+    "firstName": "Asru",
+    "lastName": "Temp 3",
+    "dob": "1970-09-03",
+    "email": "asru.temp3@example.com",
+    "asruUser": false,
+    "asruAdmin": false,
+    "asruInspector": false,
+    "asruLicensing": false,
+    "asruSupport": false,
+    "asruRops": false
+  },
+  {
+    "title": "Mr",
+    "firstName": "Asru",
+    "lastName": "Temp 4",
+    "dob": "1970-09-04",
+    "email": "asru.temp4@example.com",
+    "asruUser": false,
+    "asruAdmin": false,
+    "asruInspector": false,
+    "asruLicensing": false,
+    "asruSupport": false,
+    "asruRops": false
+  },
+  {
     "id": "a942ffc7-e7ca-4d76-a001-0b5048a057d2",
     "userId": "dee8605d-2113-4411-8a0a-dc131af87a76",
     "title": "Miss",


### PR DESCRIPTION
Adds a method for fetching and searching former ASRU staff members using the changelog table.

Adds indexes to the changelog table to help improve query performance (which may negatively impact write perf but possibly not by a noticeable amount).