### PR TITLE
Add more establishments to HOLC for testing

### DIFF
--- a/seeds/data/profiles.json
+++ b/seeds/data/profiles.json
@@ -234,6 +234,18 @@
       {
         "establishmentId": 10264,
         "role": "admin"
+      },
+      {
+        "establishmentId": 10001,
+        "role": "admin"
+      },
+      {
+        "establishmentId": 10261,
+        "role": "admin"
+      },
+      {
+        "establishmentId": 40001,
+        "role": "admin"
       }
     ]
   },


### PR DESCRIPTION
A number of the establishments HOLC has access to already have conditions by default so you can't add new conditions
Gives permission to other establishments for testing purposes