### PR TITLE
[ASL-4299] add migration to add hba title to project version

### DIFF
--- a/migrations/20230719174206_add_hba_file_name_to_project_version.js
+++ b/migrations/20230719174206_add_hba_file_name_to_project_version.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('project_versions', (table) => {
+    table.string('hba_name').nullable();
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('project_versions', (table) => {
+    table.dropColumn('hba_name');
+  });
+};

--- a/migrations/20230719174206_add_hba_file_name_to_project_version.js
+++ b/migrations/20230719174206_add_hba_file_name_to_project_version.js
@@ -1,11 +1,11 @@
 exports.up = function (knex) {
   return knex.schema.table('project_versions', (table) => {
-    table.string('hba_name').nullable();
+    table.string('hba_filename').nullable();
   });
 };
 
 exports.down = function (knex) {
   return knex.schema.table('project_versions', (table) => {
-    table.dropColumn('hba_name');
+    table.dropColumn('hba_filename');
   });
 };

--- a/schema/project-version.js
+++ b/schema/project-version.js
@@ -17,6 +17,7 @@ class ProjectVersion extends BaseModel {
         data: { type: ['object', 'null'] },
         projectId: { type: 'string', pattern: uuid.v4 },
         hbaToken: { type: ['string', 'null'] },
+        hbaTitle: { type: ['string', 'null'] },
         licenceHolderId: { type: ['string', 'null'], pattern: uuid.v4 },
         status: { type: 'string', enum: projectVersionStatuses },
         asruVersion: { type: 'boolean' },

--- a/schema/project-version.js
+++ b/schema/project-version.js
@@ -17,7 +17,7 @@ class ProjectVersion extends BaseModel {
         data: { type: ['object', 'null'] },
         projectId: { type: 'string', pattern: uuid.v4 },
         hbaToken: { type: ['string', 'null'] },
-        hbaTitle: { type: ['string', 'null'] },
+        hbaFilename: { type: ['string', 'null'] },
         licenceHolderId: { type: ['string', 'null'], pattern: uuid.v4 },
         status: { type: 'string', enum: projectVersionStatuses },
         asruVersion: { type: 'boolean' },


### PR DESCRIPTION
Allows us to retrieve the name of the stored hba file without having to do an additional request for the filename from the header of the attachments service